### PR TITLE
47 Add ready-to-use languages

### DIFF
--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -410,7 +410,7 @@ actions:
               if notification_type == 'open'
               and notification_delay != 0
             %}
-              'left_open'
+              left_open
             {% else %}
               {{ notification_type }}
             {% endif %}

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -141,6 +141,17 @@ blueprint:
               languages:
                 - en
                 - fr
+        custom_translations:
+          name: Custom translations
+          description: A json dictionary containing custom notification translations
+          default: |-
+            {
+              "title": {},
+              "message": {}
+            }
+          selector:
+            text:
+              multiline: true
 
     error_settings:
       name: Error Settings
@@ -174,6 +185,8 @@ variables:
     {% endif %}
   car_visible: !input car_visible
   language: !input language
+  custom_translations: !input custom_translations
+  custom_translations_json: "{{ custom_translations | from_json }}"
   notification_tag: |-
     {% if notification_type == 'open' %}
       gate-opening
@@ -299,8 +312,15 @@ actions:
         variables: &get_translation
           string_id: "still_open"
           title: |-
+            {# Custom translation #}
+            {%
+              if 'title' in custom_translations_json
+              and string_id in custom_translations_json['title']
+            %}
+              {{ custom_translations_json['title'][string_id] }}
+
             {# Selected language #}
-            {% if string_id in strings[language]['title'] %}
+            {% elif string_id in strings[language]['title'] %}
               {{ strings[language]['title'][string_id] }}
 
             {# Fallback to english #}
@@ -308,8 +328,15 @@ actions:
               {{ strings['en']['title'][string_id] }}
             {% endif %}
           message: |-
+            {# Custom translation #}
+            {%
+              if 'message' in custom_translations_json
+              and string_id in custom_translations_json['message']
+            %}
+              {{ custom_translations_json['message'][string_id] }}
+
             {# Selected language #}
-            {% if string_id in strings[language]['message'] %}
+            {% elif string_id in strings[language]['message'] %}
               {{ strings[language]['message'][string_id] }}
 
             {# Fallback to english #}
@@ -320,8 +347,15 @@ actions:
         variables: &get_translation_button
           string_id: "close"
           button_text: |-
+            {# Custom translation #}
+            {%
+              if 'button' in custom_translations_json
+              and string_id in custom_translations_json['button']
+            %}
+              {{ custom_translations_json['button'][string_id] }}
+
             {# Selected language #}
-            {% if string_id in strings[language]['button'] %}
+            {% elif string_id in strings[language]['button'] %}
               {{ strings[language]['button'][string_id] }}
 
             {# Fallback to english #}

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -207,10 +207,10 @@ variables:
         error: Gate error ⚠
         offline: Gate offline 🌐
       message:
-        opening: Gate is opening
+        open: Gate is opening
         still_open: Gate is still open
         left_open: Gate has been left open for {{ notification_delay }} minutes
-        closing: Gate is closing
+        close: Gate is closing
         error: "Gate has encountered an error: {{ error }}"
         offline: Gate has been offline for {{ notification_delay }} minutes
       button:
@@ -224,10 +224,10 @@ variables:
         error: Erreur portail ⚠
         offline: Portail hors ligne 🌐
       message:
-        opening: Ouverture du portail en cours
+        open: Ouverture du portail en cours
         still_open: Portail toujours ouvert
         left_open: Le portail est ouvert depuis {{ notification_delay }} minutes
-        closing: Fermeture du portail en cours
+        close: Fermeture du portail en cours
         error: "Le portail a rencontré une erreur: {{ error }}"
         offline: Le portail est hors ligne depuis {{ notification_delay }} minutes
       button:

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -140,6 +140,7 @@ blueprint:
             language:
               languages:
                 - en
+                - fr
 
     error_settings:
       name: Error Settings
@@ -201,6 +202,23 @@ variables:
         offline: Gate has been offline for {{ notification_delay }} minutes
       button:
         close: Close
+    fr:
+      title:
+        open: Ouverture portail 🔓
+        still_open: Portail ouvert 🔓
+        left_open: Portail laissé ouvert 🔓️
+        close: Fermeture portail 🔒
+        error: Erreur portail ⚠
+        offline: Portail hors ligne 🌐
+      message:
+        opening: Ouverture du portail en cours
+        still_open: Portail toujours ouvert
+        left_open: Le portail est ouvert depuis {{ notification_delay }} minutes
+        closing: Fermeture du portail en cours
+        error: "Le portail a rencontré une erreur: {{ error }}"
+        offline: Le portail est hors ligne depuis {{ notification_delay }} minutes
+      button:
+        close: Refermer
 
 trigger_variables:
   notification_type: !input notification_type

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -211,10 +211,10 @@ variables:
       message:
         open: Gate is opening
         still_open: Gate is still open
-        left_open: Gate has been left open for {{ notification_delay }} minutes
+        left_open: Gate has been left open for {notification_delay} minutes
         close: Gate is closing
-        error: "Gate has encountered an error: {{ error }}"
-        offline: Gate has been offline for {{ notification_delay }} minutes
+        error: "Gate has encountered an error: {error}"
+        offline: Gate has been offline for {notification_delay} minutes
       button:
         close: Close
     fr:
@@ -228,10 +228,10 @@ variables:
       message:
         open: Ouverture du portail en cours
         still_open: Portail toujours ouvert
-        left_open: Le portail est ouvert depuis {{ notification_delay }} minutes
+        left_open: Le portail est ouvert depuis {notification_delay} minutes
         close: Fermeture du portail en cours
-        error: "Le portail a rencontré une erreur: {{ error }}"
-        offline: Le portail est hors ligne depuis {{ notification_delay }} minutes
+        error: "Le portail a rencontré une erreur: {error}"
+        offline: Le portail est hors ligne depuis {notification_delay} minutes
       button:
         close: Refermer
 
@@ -329,7 +329,7 @@ actions:
             {% else %}
               {{ strings['en']['title'][string_id] }}
             {% endif %}
-          message: |-
+          message_string: |-
             {# Custom translation #}
             {%
               if 'message' in custom_translations_json
@@ -345,6 +345,13 @@ actions:
             {% else %}
               {{ strings['en']['message'][string_id] }}
             {% endif %}
+          message: |-
+            {{
+              message_string.format(
+                notification_delay=notification_delay,
+                error=error
+              )
+            }}
       - alias: Get button translation
         variables: &get_translation_button
           string_id: "close"

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -211,7 +211,7 @@ variables:
         still_open: Gate is still open
         left_open: Gate has been left open for {{ notification_delay }} minutes
         closing: Gate is closing
-        error: Gate has encountered an error: {{ error }}
+        error: "Gate has encountered an error: {{ error }}"
         offline: Gate has been offline for {{ notification_delay }} minutes
       button:
         close: Close

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -80,32 +80,6 @@ blueprint:
               multiple: true
               filter:
                 integration: mobile_app
-        notification_title:
-          name: 📃 Notification title
-          description: |-
-            **Title** shown in the notification
-          default: |-
-            Gate opening 🔓
-            Gate left open 🔓
-            Gate closing 🔒
-            Gate error ⚠
-            Gate offline 🌐
-          selector:
-            text:
-              multiline: true
-        notification_message:
-          name: 💬 Notification message
-          description: |-
-            **Notification** and **TTS** content. Use {{error}} for error messages and {{notification_delay}} for the notification delay
-          default: |-
-            Gate is opening
-            Gate has been left open for {{ notification_delay }} minutes
-            Gate is closing
-            Gate has encountered an error: {{ error }}
-            Gate has been offline for {{ notification_delay }} minutes
-          selector:
-            text:
-              multiline: true
         car_visible:
           name: 🚗 Visible in Android Auto/CarPlay
           description: Show notifications on your **car's dashboard**
@@ -153,32 +127,19 @@ blueprint:
           selector:
             action:
 
-    opening_settings:
-      name: Opening Settings
-      icon: "mdi:gate-open"
+    language_settings:
+      name: Language Settings
+      icon: "mdi:translate"
       collapsed: true
       input:
-        notification_still_open_title:
-          name: 📃 Notification still open title
-          description: |-
-            **Title** for notifications when the gate finishes moving and is open
-          default: Gate open 🔓
+        language:
+          name: Notification language
+          description: The language in which notifications will be sent to you
+          default: "en"
           selector:
-            text:
-        notification_still_open_message:
-          name: 💬 Notification still open message
-          description: |-
-            **Message** content for notifications when the gate finishes moving and is open
-          default: Gate is still open
-          selector:
-            text:
-              multiline: true
-        closing_button_text:
-          name: 💬 Closing Button
-          description: Text for the **close** gate **button**
-          default: Close
-          selector:
-            text:
+            language:
+              languages:
+                - en
 
     error_settings:
       name: Error Settings
@@ -210,8 +171,8 @@ variables:
     {% else %}
       {{ states(error_message_sensor) }}
     {% endif %}
-  closing_button_text: !input closing_button_text
   car_visible: !input car_visible
+  language: !input language
   notification_tag: |-
     {% if notification_type == 'open' %}
       gate-opening
@@ -222,6 +183,24 @@ variables:
     {% elif notification_type == 'offline' %}
       gate-offline
     {% endif %}
+  strings:
+    en:
+      title:
+        open: Gate opening 🔓
+        still_open: Gate open 🔓
+        left_open: Gate left open 🔓
+        close: Gate closing 🔒
+        error: Gate error ⚠
+        offline: Gate offline 🌐
+      message:
+        opening: Gate is opening
+        still_open: Gate is still open
+        left_open: Gate has been left open for {{ notification_delay }} minutes
+        closing: Gate is closing
+        error: Gate has encountered an error: {{ error }}
+        offline: Gate has been offline for {{ notification_delay }} minutes
+      button:
+        close: Close
 
 trigger_variables:
   notification_type: !input notification_type
@@ -298,14 +277,47 @@ actions:
       condition: template
       value_template: "{{ notification_type == 'open' and is_state(gate, 'open') and notification_delay == 0 and state_attr(gate, 'supported_features') | bitwise_and(4) == 4 }}"
     then:
+      - alias: Get notification translation
+        variables: &get_translation
+          string_id: "still_open"
+          title: |-
+            {# Selected language #}
+            {% if string_id in strings[language]['title'] %}
+              {{ strings[language]['title'][string_id] }}
+
+            {# Fallback to english #}
+            {% else %}
+              {{ strings['en']['title'][string_id] }}
+            {% endif %}
+          message: |-
+            {# Selected language #}
+            {% if string_id in strings[language]['message'] %}
+              {{ strings[language]['message'][string_id] }}
+
+            {# Fallback to english #}
+            {% else %}
+              {{ strings['en']['message'][string_id] }}
+            {% endif %}
+      - alias: Get button translation
+        variables: &get_translation_button
+          string_id: "close"
+          button_text: |-
+            {# Selected language #}
+            {% if string_id in strings[language]['button'] %}
+              {{ strings[language]['button'][string_id] }}
+
+            {# Fallback to english #}
+            {% else %}
+              {{ strings['en']['button'][string_id] }}
+            {% endif %}
       - alias: Replace opening notif on each phone silently
         repeat:
           for_each: "{{ notify_services }}"
           sequence:
             - action: "{{ repeat.item }}"
               data:
-                title: !input notification_still_open_title
-                message: !input notification_still_open_message
+                title: "{{ title }}"
+                message: "{{ message }}"
                 data:
                   notification_icon: mdi:gate-alert
                   channel: Gate alerts
@@ -317,7 +329,7 @@ actions:
                   alert_once: true
                   actions:
                     - action: "{{ closing_order_id }}"
-                      title: !input closing_button_text
+                      title: "{{ button_text }}"
 
       - alias: Replace opening persistent notification if enabled
         if:
@@ -326,18 +338,34 @@ actions:
         then:
           - action: persistent_notification.create
             data:
-              title: !input notification_still_open_title
-              message: !input notification_still_open_message
+              title: "{{ title }}"
+              message: "{{ message }}"
               notification_id: "{{ notification_tag }}"
     else:
+      - alias: Get notification translation
+        variables:
+          string_id: |-
+            {%
+              if notification_type == 'open'
+              and notification_delay != 0
+            %}
+              'left_open'
+            {% else %}
+              {{ notification_type }}
+            {% endif %}
+          <<: *get_translation
+      - alias: Get button translation
+        variables:
+          string_id: "close"
+          <<: *get_translation_button
       - alias: Notify each user
         repeat:
           for_each: "{{ notify_services }}"
           sequence:
             - action: "{{ repeat.item }}"
               data:
-                title: !input notification_title
-                message: !input notification_message
+                title: "{{ title }}"
+                message: "{{ message }}"
                 data:
                   car_ui: "{{ car_visible }}"
                   notification_icon: mdi:gate-alert
@@ -361,7 +389,7 @@ actions:
                   when: "{{ (utcnow() - timedelta(minutes=7)) | as_timestamp | int }}"
                   actions: |-
                     {% if notification_type == 'open' %}
-                      {{ [{'action': closing_order_id, 'title': closing_button_text}] }}
+                      {{ [{'action': closing_order_id, 'title': button_text}] }}
                     {% else %}
                       {{ [] }}
                     {% endif %}
@@ -375,7 +403,7 @@ actions:
                   data:
                     message: TTS
                     data:
-                      tts_text: !input notification_message
+                      tts_text: "{{ message }}"
                       channel: Gate alerts
                       importance: max
                       ttl: 0
@@ -388,7 +416,7 @@ actions:
               data:
                 cache: true
                 media_player_entity_id: "{{ repeat.item }}"
-                message: !input notification_message
+                message: "{{ message }}"
               target: "{{ speaker_tts_service }}"
 
       - alias: Send persistent notification to dashboard, if enabled
@@ -398,8 +426,8 @@ actions:
         then:
           - action: persistent_notification.create
             data:
-              title: !input notification_title
-              message: !input notification_message
+              title: "{{ title }}"
+              message: "{{ message }}"
               notification_id: "{{ notification_tag }}"
 
       - alias: Exec user extra actions

--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -134,7 +134,7 @@ blueprint:
       input:
         language:
           name: Notification language
-          description: The language in which notifications will be sent to you
+          description: The **language** in which **notifications** will be sent to you
           default: "en"
           selector:
             language:
@@ -143,7 +143,9 @@ blueprint:
                 - fr
         custom_translations:
           name: Custom translations
-          description: A json dictionary containing custom notification translations
+          description: |-
+            A **json** dictionary to change the default **notifications translations**
+            *Note : You can find the translation keys in the strings['en'] variable in the code or in your traces*
           default: |-
             {
               "title": {},

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -175,6 +175,17 @@ blueprint:
               languages:
                 - en
                 - fr
+        custom_translations:
+          name: Custom translations
+          description: A json dictionary containing custom notification translations
+          default: |-
+            {
+              "title": {},
+              "message": {}
+            }
+          selector:
+            text:
+              multiline: true
         notif_refresh_rate_ftn:
           name: 🔁 Notification refresh rate function
           description: |-
@@ -207,6 +218,9 @@ variables:
   nearly_arrived_tts: !input nearly_arrived_tts
   driver_arrived_tts: !input driver_arrived_tts
   nearly_arrived_time: !input nearly_arrived_time
+  language: !input language
+  custom_translations: !input custom_translations
+  custom_translations_json: "{{ custom_translations | from_json }}"
   strings:
     en:
       message:
@@ -275,8 +289,15 @@ actions:
     variables: &get_translation
       message_id: "itinerary_started"
       message: |-
+        {# Custom translation #}
+        {%
+          if 'title' in custom_translations_json
+          and title_id in custom_translations_json['title']
+        %}
+          {{ custom_translations_json['title'][title_id] }}
+
         {# Selected language #}
-        {% if message_id in strings[language]['message_id'] %}
+        {% elif message_id in strings[language]['message_id'] %}
           {{ strings[language]['title'][message_id] }}
 
         {# Fallback to english #}

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -298,7 +298,7 @@ actions:
           {{ custom_translations_json['message'][message_id] }}
 
         {# Selected language #}
-        {% elif message_id in strings[language]['message_id'] %}
+        {% elif message_id in strings[language]['message'] %}
           {{ strings[language]['message'][message_id] }}
 
         {# Fallback to english #}

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -211,7 +211,7 @@ variables:
     en:
       message:
         itinerary_started: "{{ driver_name }} just got into his car"
-        itinerary_ongoing: "{{ driver_name }} will arrive approximately at {{ arrival }}"
+        itinerary_ongoing: "{{ driver_name }} will arrive arround {{ arrival }}"
         nearly_arrived: "{{ driver_name }} will arrive in {{ remaining_minutes }} minutes"
         driver_arrived: "{{ driver_name }} just arrived home"
     fr:

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -166,6 +166,14 @@ blueprint:
       icon: mdi:cog
       collapsed: true
       input:
+        language:
+          name: Notification language
+          description: The language in which notifications will be sent to you
+          default: "en"
+          selector:
+            language:
+              languages:
+                - en
         notif_refresh_rate_ftn:
           name: 🔁 Notification refresh rate function
           description: |-
@@ -180,38 +188,6 @@ blueprint:
             The **link** you will go to if you **tap** on the notification
             *Note : Can be Home Assistant relative links*
           default: "/lovelace/vehicle-tracker-map"
-          selector:
-            text:
-        itinerary_started_message:
-          name: 💬 Itinerary started notification
-          description: |-
-            The **content** of the notification or TTS you will receive when someone **begins to drive**
-            *Note : {{driver_name}} will be replaced by the drivers' name*
-          default: "{{ driver_name }} just got into his car"
-          selector:
-            text:
-        itinerary_ongoing_message:
-          name: 💬 Itinerary ongoing notification
-          description: |-
-            The **content** of the notification you will receive while receiving new **travel time updates**
-            *Note : {{driver_name}} will be replaced by the drivers' name and {{arrival}} by its ETA*
-          default: "{{ driver_name }} will arrive approximately at {{ arrival }}"
-          selector:
-            text:
-        nearly_arrived_message:
-          name: 💬 Driver has nearly arrived notification
-          description: |-
-            The **content** of the notification you will receive when the driver has **arrived**
-            *Note : {{driver_name}} will be replaced by the drivers' name and {remaining_minutes} by its remaining time*
-          default: "{{ driver_name }} will arrive in {{ remaining_minutes }} minutes"
-          selector:
-            text:
-        driver_arrived_message:
-          name: 💬 Driver has arrived notification
-          description: |-
-            The **content** of the notification you will receive when the driver has **arrived**
-            *Note : {{driver_name}} will be replaced by the drivers' name*
-          default: "{{ driver_name }} just arrived home"
           selector:
             text:
 
@@ -230,6 +206,13 @@ variables:
   nearly_arrived_tts: !input nearly_arrived_tts
   driver_arrived_tts: !input driver_arrived_tts
   nearly_arrived_time: !input nearly_arrived_time
+  strings:
+    en:
+      message:
+        itinerary_started: "{{ driver_name }} just got into his car"
+        itinerary_ongoing: "{{ driver_name }} will arrive approximately at {{ arrival }}"
+        nearly_arrived: "{{ driver_name }} will arrive in {{ remaining_minutes }} minutes"
+        driver_arrived: "{{ driver_name }} just arrived home"
 
 triggers:
   - trigger: state
@@ -281,13 +264,25 @@ actions:
   - alias: Only continue if driver not home
     condition: template
     value_template: "{{ not is_state(driver, 'home') }}"
+  - alias: Get notification translation
+    variables: &get_translation
+      message_id: "itinerary_started"
+      message: |-
+        {# Selected language #}
+        {% if message_id in strings[language]['message_id'] %}
+          {{ strings[language]['title'][message_id] }}
+
+        {# Fallback to english #}
+        {% else %}
+          {{ strings['en']['title'][message_id] }}
+        {% endif %}
   - alias: Notify each user except the driver about itinerary start
     repeat:
       for_each: "{{ notify_services }}"
       sequence:
         - action: "{{ repeat.item }}"
           data:
-            message: !input itinerary_started_message
+            message: "{{ message }}"
             data:
               notification_icon: mdi:car
               tag: itinerary-tracker
@@ -317,7 +312,7 @@ actions:
               data:
                 cache: true
                 media_player_entity_id: "{{ repeat.item }}"
-                message: !input itinerary_started_message
+                message: "{{ message }}"
               target: "{{ speaker_tts_service }}"
   - alias: If travel time sensors set
     if:
@@ -381,6 +376,10 @@ actions:
                       and persons | select('is_state', 'home') | list != []
                     }}
               then:
+                - alias: Get TTS translation
+                  variables:
+                    message_id: "nearly_arrived"
+                    <<: *get_translation
                 - alias: Play TTS on each device
                   repeat:
                     for_each: "{{ speaker_tts_devices }}"
@@ -389,7 +388,7 @@ actions:
                         data:
                           cache: true
                           media_player_entity_id: "{{ repeat.item }}"
-                          message: !input nearly_arrived_message
+                          message: "{{ message }}"
                         target: "{{ speaker_tts_service }}"
                 - alias: Mark nearly arrived TTS as already sent
                   variables:
@@ -406,13 +405,17 @@ actions:
                 remaining_minutes: "{{ (remaining/60) | round }}"
                 arrival_timestamp: "{{ as_timestamp(now()) + remaining }}"
                 arrival: "{{ arrival_timestamp | timestamp_custom('%H:%M') }}"
+            - alias: Get notification translation
+              variables:
+                message_id: "itinerary_ongoing"
+                <<: *get_translation
             - alias: Send ETA notification to each user
               repeat:
                 for_each: "{{ notify_services }}"
                 sequence:
                   - action: "{{ repeat.item }}"
                     data:
-                      message: !input itinerary_ongoing_message
+                      message: "{{ message }}"
                       data:
                         notification_icon: mdi:map-marker-account
                         tag: itinerary-tracker
@@ -438,6 +441,10 @@ actions:
                       and persons | select('is_state', 'home') | list != []
                     }}
               then:
+                - alias: Get TTS translation
+                  variables:
+                    message_id: "nearly_arrived"
+                    <<: *get_translation
                 - alias: Play TTS on each device
                   repeat:
                     for_each: "{{ speaker_tts_devices }}"
@@ -446,7 +453,7 @@ actions:
                         data:
                           cache: true
                           media_player_entity_id: "{{ repeat.item }}"
-                          message: !input nearly_arrived_message
+                          message: "{{ message }}"
                         target: "{{ speaker_tts_service }}"
                 - alias: Mark nearly arrived TTS as already sent
                   variables:
@@ -465,13 +472,17 @@ actions:
       condition: template
       value_template: "{{ is_state(driver, 'home') }}"
     then:
+      - alias: Get notification translation
+        variables:
+          message_id: "driver_arrived"
+          <<: *get_translation
       - alias: Send arrival notification to each user
         repeat:
           for_each: "{{ notify_services }}"
           sequence:
             - action: "{{ repeat.item }}"
               data:
-                message: !input driver_arrived_message
+                message: "{{ message }}"
                 data:
                   notification_icon: mdi:home-map-marker
                   tag: itinerary-tracker
@@ -497,7 +508,7 @@ actions:
                   data:
                     cache: true
                     media_player_entity_id: "{{ repeat.item }}"
-                    message: !input driver_arrived_message
+                    message: "{{ message }}"
                   target: "{{ speaker_tts_service }}"
     else:
       - alias: Remove itinerary notification for each user

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -180,7 +180,6 @@ blueprint:
           description: A json dictionary containing custom notification translations
           default: |-
             {
-              "title": {},
               "message": {}
             }
           selector:
@@ -291,18 +290,18 @@ actions:
       message: |-
         {# Custom translation #}
         {%
-          if 'title' in custom_translations_json
-          and title_id in custom_translations_json['title']
+          if 'message' in custom_translations_json
+          and message_id in custom_translations_json['message']
         %}
-          {{ custom_translations_json['title'][title_id] }}
+          {{ custom_translations_json['message'][message_id] }}
 
         {# Selected language #}
         {% elif message_id in strings[language]['message_id'] %}
-          {{ strings[language]['title'][message_id] }}
+          {{ strings[language]['message'][message_id] }}
 
         {# Fallback to english #}
         {% else %}
-          {{ strings['en']['title'][message_id] }}
+          {{ strings['en']['message'][message_id] }}
         {% endif %}
   - alias: Notify each user except the driver about itinerary start
     repeat:

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -168,7 +168,7 @@ blueprint:
       input:
         language:
           name: Notification language
-          description: The language in which notifications will be sent to you
+          description: The **language** in which **notifications** will be sent to you
           default: "en"
           selector:
             language:
@@ -177,7 +177,9 @@ blueprint:
                 - fr
         custom_translations:
           name: Custom translations
-          description: A json dictionary containing custom notification translations
+          description: |-
+            A **json** dictionary to change the default **notifications translations**
+            *Note : You can find the translation keys in the strings['en'] variable in the code or in your traces*
           default: |-
             {
               "message": {}

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -225,16 +225,16 @@ variables:
   strings:
     en:
       message:
-        itinerary_started: "{{ driver_name }} just got into his car"
-        itinerary_ongoing: "{{ driver_name }} will arrive arround {{ arrival }}"
-        nearly_arrived: "{{ driver_name }} will arrive in {{ remaining_minutes }} minutes"
-        driver_arrived: "{{ driver_name }} just arrived home"
+        itinerary_started: "{driver_name} just got into his car"
+        itinerary_ongoing: "{driver_name} will arrive arround {arrival}"
+        nearly_arrived: "{driver_name} will arrive in {remaining_minutes} minutes"
+        driver_arrived: "{driver_name} just arrived home"
     fr:
       message:
-        itinerary_started: "{{ driver_name }} vient de monter dans sa voiture"
-        itinerary_ongoing: "{{ driver_name }} arrivera vers {{ arrival }}"
-        nearly_arrived: "{{ driver_name }} arrivera dans {{ remaining_minutes }} minutes"
-        driver_arrived: "{{ driver_name }} vient d'arriver à la maison"
+        itinerary_started: "{driver_name} vient de monter dans sa voiture"
+        itinerary_ongoing: "{driver_name} arrivera vers {arrival}"
+        nearly_arrived: "{driver_name} arrivera dans {remaining_minutes} minutes"
+        driver_arrived: "{driver_name} vient d'arriver à la maison"
 
 triggers:
   - trigger: state
@@ -289,7 +289,7 @@ actions:
   - alias: Get notification translation
     variables: &get_translation
       message_id: "itinerary_started"
-      message: |-
+      message_string: |-
         {# Custom translation #}
         {%
           if 'message' in custom_translations_json
@@ -305,6 +305,14 @@ actions:
         {% else %}
           {{ strings['en']['message'][message_id] }}
         {% endif %}
+      message: |-
+        {{
+          message_string.format(
+            driver_name=driver_name,
+            arrival=arrival,
+            remaining_minutes=remaining_minutes
+          )
+        }}
   - alias: Notify each user except the driver about itinerary start
     repeat:
       for_each: "{{ notify_services }}"

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -225,7 +225,7 @@ variables:
   strings:
     en:
       message:
-        itinerary_started: "{driver_name} just got into his car"
+        itinerary_started: "{driver_name} just got into their car"
         itinerary_ongoing: "{driver_name} will arrive arround {arrival}"
         nearly_arrived: "{driver_name} will arrive in {remaining_minutes} minutes"
         driver_arrived: "{driver_name} just arrived home"

--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -174,6 +174,7 @@ blueprint:
             language:
               languages:
                 - en
+                - fr
         notif_refresh_rate_ftn:
           name: 🔁 Notification refresh rate function
           description: |-
@@ -213,6 +214,12 @@ variables:
         itinerary_ongoing: "{{ driver_name }} will arrive approximately at {{ arrival }}"
         nearly_arrived: "{{ driver_name }} will arrive in {{ remaining_minutes }} minutes"
         driver_arrived: "{{ driver_name }} just arrived home"
+    fr:
+      message:
+        itinerary_started: "{{ driver_name }} vient de monter dans sa voiture"
+        itinerary_ongoing: "{{ driver_name }} arrivera vers {{ arrival }}"
+        nearly_arrived: "{{ driver_name }} arrivera dans {{ remaining_minutes }} minutes"
+        driver_arrived: "{{ driver_name }} vient d'arriver à la maison"
 
 triggers:
   - trigger: state

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -439,8 +439,18 @@ actions:
                 variables: &get_translation
                   title_id: "itinerary_canceled"
                   message_id: "triggered_frequently"
-                  title: "{{ strings[language]['title'][title_id] }}"
-                  message: "{{ strings[language]['message'][message_id] }}"
+                  title: |-
+                    {% if title_id in strings[language]['title'] %}
+                      {{ strings[language]['title'][title_id] }}
+                    {% else %}
+                      {{ strings['en']['title'][title_id] }}
+                    {% endif %}
+                  message: |-
+                    {% if message_id in strings[language]['message'] %}
+                      {{ strings[language]['message'][message_id] }}
+                    {% else %}
+                      {{ strings['en']['message'][message_id] }}
+                    {% endif %}
               - alias: Notify driver that the blueprint is being triggered frequently
                 action: "{{ notify_service }}"
                 data:

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -412,12 +412,6 @@ variables:
           L'automation s'est déclenchée {{ consecutive_errors }} fois d'affilée
           Réactivez l'automatisation manuellement une fois le problème corrigé
 
-    timed_out_message: La position a mis trop de temps à se rafraîchir
-    vehicle_away_message:
-    travel_time_did_not_respond:
-
-
-
 triggers:
   - alias: Trigger when user connects to vehicle
     trigger: state

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -241,6 +241,14 @@ blueprint:
       collapsed: true
       description: |-
         Notification settings to translate texts or change notification behavior
+      input:
+        language:
+          name: Notification language
+          default: "en"
+          selector:
+            language:
+              languages:
+                - en
 
     optional_sensors:
       name: Optional sensors
@@ -339,6 +347,7 @@ variables:
   continuously_refresh_interval: !input continuously_refresh_interval
   eta_zone: !input eta_zone
   activation_zone: !input activation_zone
+  language: !input language
   ble_entities: !input ble_entities
   ble_scanner_switch: !input ble_scanner_switch
   ble_transmitter_entities: !input ble_transmitter_entities
@@ -347,25 +356,26 @@ variables:
   only_open_near_iBeacon: !input only_open_near_iBeacon
   wifi_devices: !input wifi_devices
   strings:
-    title:
-      itinerary_update: "Itinerary ℹ️"
-      itinerary_canceled: "Itinerary canceled ❌"
-      awaiting: "Gate awaiting {{ awaiting_persons }} 💤"
-      disabled: "Automatic Gate disabled 🚫"
-    message:
-      itinerary_started: "Your itinerary has been started"
-      awaiting: "The gate will close once all users have entered/exited"
-      vehicle_left: "You have left your vehicle"
-      did_not_leave: "The vehicle did not leave in less than {{ safety_delay }} minutes"
-      did_not_arrive: "The vehicle did not arrive in less than {{ safety_delay }} minutes"
-      timed_out: "Your position has not been updated in {{ timeout_delay }} minutes"
-      vehicle_away: "The vehicle is not in the activation zone"
-      travel_time_did_not_respond: "Your travel time integration did not respond during your itinerary"
-      not_home: "You were not detected at home"
-      triggered_frequently: "The blueprint is being triggered repeatedly !"
-      disabled_triggered_frequently: |-
-        The blueprint has been triggered {{ consecutive_errors }} times in a row
-        Please enable the blueprint manually once the issue has been fixed
+    en:
+      title:
+        itinerary_update: "Itinerary ℹ️"
+        itinerary_canceled: "Itinerary canceled ❌"
+        awaiting: "Gate awaiting {{ awaiting_persons }} 💤"
+        disabled: "Automatic Gate disabled 🚫"
+      message:
+        itinerary_started: "Your itinerary has been started"
+        awaiting: "The gate will close once all users have entered/exited"
+        vehicle_left: "You have left your vehicle"
+        did_not_leave: "The vehicle did not leave in less than {{ safety_delay }} minutes"
+        did_not_arrive: "The vehicle did not arrive in less than {{ safety_delay }} minutes"
+        timed_out: "Your position has not been updated in {{ timeout_delay }} minutes"
+        vehicle_away: "The vehicle is not in the activation zone"
+        travel_time_did_not_respond: "Your travel time integration did not respond during your itinerary"
+        not_home: "You were not detected at home"
+        triggered_frequently: "The blueprint is being triggered repeatedly !"
+        disabled_triggered_frequently: |-
+          The blueprint has been triggered {{ consecutive_errors }} times in a row
+          Please enable the blueprint manually once the issue has been fixed
 
 triggers:
   - alias: Trigger when user connects to vehicle
@@ -425,12 +435,12 @@ actions:
               - condition: template
                 value_template: "{{ consecutive_errors == 1 }}"
             sequence:
-              - alias: Get notification content
+              - alias: Get notification translation
                 variables: &get_translation
                   title_id: "itinerary_canceled"
                   message_id: "triggered_frequently"
-                  title: "{{ strings['title'][title_id] }}"
-                  message: "{{ strings['message'][message_id] }}"
+                  title: "{{ strings[language]['title'][title_id] }}"
+                  message: "{{ strings[language]['message'][message_id] }}"
               - alias: Notify driver that the blueprint is being triggered frequently
                 action: "{{ notify_service }}"
                 data:
@@ -452,7 +462,7 @@ actions:
               - condition: template
                 value_template: "{{ consecutive_errors == 3 }}"
             sequence:
-              - alias: Get notification content
+              - alias: Get notification translation
                 variables:
                   title_id: "disabled"
                   message_id: "disabled_triggered_frequently"
@@ -578,7 +588,7 @@ actions:
             - condition: template
               value_template: "{{ wait.remaining == 0 }}"
             then:
-              - alias: Get notification content
+              - alias: Get notification translation
                 variables:
                   title_id: "itinerary_canceled"
                   message_id: "not_home"
@@ -726,7 +736,7 @@ actions:
                   - condition: template
                     value_template: "{{ wait.remaining == 0 }}"
                 then:
-                  - alias: Get notification content
+                  - alias: Get notification translation
                     variables:
                       title_id: "itinerary_canceled"
                       message_id: "did_not_leave"
@@ -779,7 +789,7 @@ actions:
                     {% endfor %}
 
                     {{ data.awaiting_persons | join(', ') }}
-              - alias: Get notification content
+              - alias: Get notification translation
                 variables:
                   title_id: "awaiting"
                   message_id: "awaiting"
@@ -862,7 +872,7 @@ actions:
       entity_id: "{{ itinerary_sensor }}"
     data:
       value: arriving
-  - alias: Get notification content
+  - alias: Get notification translation
     variables:
       title_id: "itinerary_update"
       message_id: "itinerary_started"
@@ -990,7 +1000,7 @@ actions:
                               entity_id: "{{ itinerary_sensor }}"
                             data:
                               value: none
-                          - alias: Get notification content
+                          - alias: Get notification translation
                             variables:
                               title_id: "itinerary_canceled"
                               message_id: "timed_out"
@@ -1028,7 +1038,7 @@ actions:
                       entity_id: "{{ itinerary_sensor }}"
                     data:
                       value: none
-                  - alias: Get notification content
+                  - alias: Get notification translation
                     variables:
                       title_id: "itinerary_canceled"
                       message_id: "vehicle_away"
@@ -1126,7 +1136,7 @@ actions:
                                 {% endfor %}
 
                                 {{ data.awaiting_persons | join(', ') }}
-                          - alias: Get notification content
+                          - alias: Get notification translation
                             variables:
                               title_id: "awaiting"
                               message_id: "awaiting"
@@ -1157,7 +1167,7 @@ actions:
                                   - condition: template
                                     value_template: "{{ wait.remaining == 0 }}"
                                 sequence:
-                                  - alias: Get notification content
+                                  - alias: Get notification translation
                                     variables:
                                       title_id: "itinerary_canceled"
                                       message_id: "did_not_arrive"
@@ -1183,7 +1193,7 @@ actions:
                                   - condition: template
                                     value_template: "{{ wait.trigger.id == 'activation_zone_left' }}"
                                 sequence:
-                                  - alias: Get notification content
+                                  - alias: Get notification translation
                                     variables:
                                       title_id: "itinerary_canceled"
                                       message_id: "vehicle_away"
@@ -1231,7 +1241,7 @@ actions:
                                   - condition: template
                                     value_template: "{{ wait.trigger.id == 'vehicle_left' }}"
                                 sequence:
-                                  - alias: Get notification content
+                                  - alias: Get notification translation
                                     variables:
                                       title_id: "itinerary_canceled"
                                       message_id: "vehicle_left"
@@ -1320,7 +1330,7 @@ actions:
       value_template: "{{ is_state(person, [state_attr(gate_location, 'friendly_name'), states[gate_location].object_id])
         and states[travel_time_sensor].last_updated < now() - timedelta(minutes=5) }}"
     then:
-      - alias: Get notification content
+      - alias: Get notification translation
         variables:
           title_id: "itinerary_canceled"
           message_id: "travel_time_did_not_respond"
@@ -1342,7 +1352,7 @@ actions:
             tag: itinerary-status
             timeout: 300
     else:
-      - alias: Get notification content
+      - alias: Get notification translation
         variables:
           title_id: "itinerary_canceled"
           message_id: "vehicle_left"

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -241,120 +241,6 @@ blueprint:
       collapsed: true
       description: |-
         Notification settings to translate texts or change notification behavior
-      input:
-        itinerary_update_title:
-          name: 📃ℹ️ Itinerary status update title
-          description: The **title** displayed on the notification you will receive when the **status of your itinerary** changes
-          default: "Itinerary ℹ️"
-          selector:
-            text:
-        itinerary_canceled_title:
-          name: 📃❌ Itinerary canceled title
-          description: The **title** displayed on the notification you will receive when your **itinerary gets canceled**
-          default: "Itinerary canceled ❌"
-          selector:
-            text:
-        awaiting_title:
-          name: 📃💤 Gate awaiting user notification title
-          description: |-
-            The **title** displayed on the notification you will receive when your gate is **awaiting another user**
-            *Note : {{awaiting_persons}} will be replaced by the list of the users being awaited*
-          default: "Gate awaiting {{ awaiting_persons }} 💤"
-          selector:
-            text:
-        disabled_title:
-          name: 📃🚫 Blueprint disabled notification title
-          description: The **title** displayed on the notification you will receive when the blueprints **disables itself**
-          default: "Automatic Gate disabled 🚫"
-          selector:
-            text:
-        itinerary_started_message:
-          name: 💬🚀 Itinerary started notification
-          description: The **content** of the notification you will receive when your **itinerary starts**
-          default: "Your itinerary has been started"
-          selector:
-            text:
-              multiline: true
-        awaiting_message:
-          name: 💬💤 Gate awaiting user notification
-          description: The **content** of the notification you will receive when your gate is **awaiting another user**
-          default: "The gate will close once all users have entered/exited"
-          selector:
-            text:
-              multiline: true
-        vehicle_left_message:
-          name: 💬⚠️ Vehicle left notification
-          description: The **content** of the notification you will receive if you **leave your vehicle**
-          default: "You have left your vehicle"
-          selector:
-            text:
-              multiline: true
-        did_not_leave_message:
-          name: 💬⚠️ User did not leave notification
-          description: |-
-            The **content** of the notification you will receive if you **don't leave in time**
-            *Note : {{safety_delay}} will be replaced by your auto-close delay you have set above*
-          default: "The vehicle did not leave in less than {{ safety_delay }} minutes"
-          selector:
-            text:
-              multiline: true
-        did_not_arrive_message:
-          name: 💬⚠️ User did not arrive notification
-          description: |-
-            The **content** of the notification you will receive if you **don't arrive in time**
-            *Note : {{safety_delay}} will be replaced by your auto-close delay you have set above*
-          default: "The vehicle did not arrive in less than {{ safety_delay }} minutes"
-          selector:
-            text:
-              multiline: true
-        timed_out_message:
-          name: 💬⚠️ Timed out notification
-          description: |-
-            The **content** of the notification you will receive if you **time out**
-            *Note : {{timeout_delay}} will be replaced by your auto-close delay you have set above*
-          default: "Your position has not been updated in {{ timeout_delay }} minutes"
-          selector:
-            text:
-              multiline: true
-        vehicle_away_message:
-          name: 💬⚠️ Vehicle not in activation zone notification
-          description: The **content** of the notification you will receive if **you are not in your activation zone**
-          default: "The vehicle is not in the activation zone"
-          selector:
-            text:
-              multiline: true
-        travel_time_did_not_respond:
-          name: 💬⚠️ Travel time integration did not respond
-          description: The **content** of the notification you will receive if your **travel time integraton did not respond** during the itinerary
-          default: "Your travel time integration did not respond during your itinerary"
-          selector:
-            text:
-              multiline: true
-        not_home_message:
-          name: 💬⚠️ Not home notification
-          description: The **content** of the notification you will receive if your **iBeacon or WiFi tracker** did not report you at home
-          default: "You were not detected at home"
-          selector:
-            text:
-              multiline: true
-        triggered_frequently_message:
-          name: 💬⚠️ Triggered frequently notification
-          description: The **content** of the notification you will receive if the blueprint is **triggered too frequently**
-          default: "The blueprint is being triggered repeatedly !"
-          selector:
-            text:
-              multiline: true
-        disabled_triggered_frequently_message:
-          name: 💬⚠️ Blueprint disabled notification
-          description: |-
-            The **content** of the notification you will receive if the blueprint **disables itself** after being **triggered too frequently**
-            *Note : {{consecutive_errors}} will be replaced by the number of times the error occurred*
-          default: |-
-            The blueprint has been triggered {{ consecutive_errors }} times in a row
-            Please enable the blueprint manually once the issue has been fixed
-          selector:
-            text:
-              multiline: true
 
     optional_sensors:
       name: Optional sensors
@@ -460,6 +346,26 @@ variables:
   only_open_near_wifi: !input only_open_near_wifi
   only_open_near_iBeacon: !input only_open_near_iBeacon
   wifi_devices: !input wifi_devices
+  strings:
+    title:
+      itinerary_update: "Itinerary ℹ️"
+      itinerary_canceled: "Itinerary canceled ❌"
+      awaiting: "Gate awaiting {{ awaiting_persons }} 💤"
+      disabled: "Automatic Gate disabled 🚫"
+    message:
+      itinerary_started: "Your itinerary has been started"
+      awaiting: "The gate will close once all users have entered/exited"
+      vehicle_left: "You have left your vehicle"
+      did_not_leave: "The vehicle did not leave in less than {{ safety_delay }} minutes"
+      did_not_arrive: "The vehicle did not arrive in less than {{ safety_delay }} minutes"
+      timed_out: "Your position has not been updated in {{ timeout_delay }} minutes"
+      vehicle_away: "The vehicle is not in the activation zone"
+      travel_time_did_not_respond: "Your travel time integration did not respond during your itinerary"
+      not_home: "You were not detected at home"
+      triggered_frequently: "The blueprint is being triggered repeatedly !"
+      disabled_triggered_frequently: |-
+        The blueprint has been triggered {{ consecutive_errors }} times in a row
+        Please enable the blueprint manually once the issue has been fixed
 
 triggers:
   - alias: Trigger when user connects to vehicle
@@ -519,11 +425,17 @@ actions:
               - condition: template
                 value_template: "{{ consecutive_errors == 1 }}"
             sequence:
+              - alias: Get notification content
+                variables: &get_translation
+                  title_id: "itinerary_canceled"
+                  message_id: "triggered_frequently"
+                  title: "{{ strings['title'][title_id] }}"
+                  message: "{{ strings['message'][message_id] }}"
               - alias: Notify driver that the blueprint is being triggered frequently
                 action: "{{ notify_service }}"
                 data:
-                  title: !input itinerary_canceled_title
-                  message: !input triggered_frequently_message
+                  title: "{{ title }}"
+                  message: "{{ message }}"
                   data:
                     car_ui: true
                     notification_icon: mdi:alert-circle
@@ -540,11 +452,16 @@ actions:
               - condition: template
                 value_template: "{{ consecutive_errors == 3 }}"
             sequence:
+              - alias: Get notification content
+                variables:
+                  title_id: "disabled"
+                  message_id: "disabled_triggered_frequently"
+                  <<: *get_translation
               - alias: Notify driver that the blueprint is disabling itself
                 action: "{{ notify_service }}"
                 data:
-                  title: !input disabled_title
-                  message: !input disabled_triggered_frequently_message
+                  title: "{{ title }}"
+                  message: "{{ message }}"
                   data:
                     car_ui: true
                     notification_icon: mdi:alert-circle
@@ -559,8 +476,8 @@ actions:
               - alias: Notify all users on the dashboard that the blueprint has disabled itself
                 action: persistent_notification.create
                 data:
-                  title: !input disabled_title
-                  message: !input disabled_triggered_frequently_message
+                  title: "{{ title }}"
+                  message: "{{ message }}"
               - alias: Disable the blueprint
                 action: automation.turn_off
                 target:
@@ -661,11 +578,16 @@ actions:
             - condition: template
               value_template: "{{ wait.remaining == 0 }}"
             then:
+              - alias: Get notification content
+                variables:
+                  title_id: "itinerary_canceled"
+                  message_id: "not_home"
+                  <<: *get_translation
               - alias: Notify driver of itinerary cancelation as he was not home
                 action: "{{ notify_service }}"
                 data:
-                  title: !input itinerary_canceled_title
-                  message: !input not_home_message
+                  title: "{{ title }}"
+                  message: "{{ message }}"
                   data:
                     car_ui: true
                     notification_icon: mdi:alert-circle
@@ -804,11 +726,16 @@ actions:
                   - condition: template
                     value_template: "{{ wait.remaining == 0 }}"
                 then:
+                  - alias: Get notification content
+                    variables:
+                      title_id: "itinerary_canceled"
+                      message_id: "did_not_leave"
+                      <<: *get_translation
                   - alias: Notify driver of itinerary cancelation as he didn't leave in time
                     action: "{{ notify_service }}"
                     data:
-                      title: !input itinerary_canceled_title
-                      message: !input did_not_leave_message
+                      title: "{{ title }}"
+                      message: "{{ message }}"
                       data:
                         car_ui: true
                         notification_icon: mdi:alert-circle
@@ -852,11 +779,16 @@ actions:
                     {% endfor %}
 
                     {{ data.awaiting_persons | join(', ') }}
+              - alias: Get notification content
+                variables:
+                  title_id: "awaiting"
+                  message_id: "awaiting"
+                  <<: *get_translation
               - alias: Notify driver that gate will wait for next person
                 action: "{{ notify_service }}"
                 data:
-                  title: !input awaiting_title
-                  message: !input awaiting_message
+                  title: "{{ title }}"
+                  message: "{{ message }}"
                   data:
                     car_ui: true
                     notification_icon: mdi:sleep
@@ -930,11 +862,16 @@ actions:
       entity_id: "{{ itinerary_sensor }}"
     data:
       value: arriving
+  - alias: Get notification content
+    variables:
+      title_id: "itinerary_update"
+      message_id: "itinerary_started"
+      <<: *get_translation
   - alias: Notify driver of itinerary start
     action: "{{ notify_service }}"
     data:
-      title: !input itinerary_update_title
-      message: !input itinerary_started_message
+      title: "{{ title }}"
+      message: "{{ message }}"
       data:
         car_ui: true
         notification_icon: mdi:map-check
@@ -1053,11 +990,16 @@ actions:
                               entity_id: "{{ itinerary_sensor }}"
                             data:
                               value: none
+                          - alias: Get notification content
+                            variables:
+                              title_id: "itinerary_canceled"
+                              message_id: "timed_out"
+                              <<: *get_translation
                           - alias: Notify driver about itinerary cancellation
                             action: "{{ notify_service }}"
                             data:
-                              title: !input itinerary_canceled_title
-                              message: !input timed_out_message
+                              title: "{{ title }}"
+                              message: "{{ message }}"
                               data:
                                 car_ui: true
                                 notification_icon: mdi:alert-circle
@@ -1086,11 +1028,16 @@ actions:
                       entity_id: "{{ itinerary_sensor }}"
                     data:
                       value: none
+                  - alias: Get notification content
+                    variables:
+                      title_id: "itinerary_canceled"
+                      message_id: "vehicle_away"
+                      <<: *get_translation
                   - alias: Notify driver about itinerary cancellation
                     action: "{{ notify_service }}"
                     data:
-                      title: !input itinerary_canceled_title
-                      message: !input vehicle_away_message
+                      title: "{{ title }}"
+                      message: "{{ message }}"
                       data:
                         car_ui: true
                         notification_icon: mdi:alert-circle
@@ -1179,11 +1126,16 @@ actions:
                                 {% endfor %}
 
                                 {{ data.awaiting_persons | join(', ') }}
+                          - alias: Get notification content
+                            variables:
+                              title_id: "awaiting"
+                              message_id: "awaiting"
+                              <<: *get_translation
                           - alias: Notify driver that gate will wait for next person
                             action: "{{ notify_service }}"
                             data:
-                              title: !input awaiting_title
-                              message: !input awaiting_message
+                              title: "{{ title }}"
+                              message: "{{ message }}"
                               data:
                                 car_ui: true
                                 notification_icon: mdi:sleep
@@ -1205,11 +1157,16 @@ actions:
                                   - condition: template
                                     value_template: "{{ wait.remaining == 0 }}"
                                 sequence:
+                                  - alias: Get notification content
+                                    variables:
+                                      title_id: "itinerary_canceled"
+                                      message_id: "did_not_arrive"
+                                      <<: *get_translation
                                   - alias: Notify driver of itinerary cancelation as he took too long
                                     action: "{{ notify_service }}"
                                     data:
-                                      title: !input itinerary_canceled_title
-                                      message: !input did_not_arrive_message
+                                      title: "{{ title }}"
+                                      message: "{{ message }}"
                                       data:
                                         car_ui: true
                                         notification_icon: mdi:alert-circle
@@ -1226,11 +1183,16 @@ actions:
                                   - condition: template
                                     value_template: "{{ wait.trigger.id == 'activation_zone_left' }}"
                                 sequence:
+                                  - alias: Get notification content
+                                    variables:
+                                      title_id: "itinerary_canceled"
+                                      message_id: "vehicle_away"
+                                      <<: *get_translation
                                   - alias: Notify driver of itinerary cancelation as he exited the zone
                                     action: "{{ notify_service }}"
                                     data:
-                                      title: !input itinerary_canceled_title
-                                      message: !input vehicle_away_message
+                                      title: "{{ title }}"
+                                      message: "{{ message }}"
                                       data:
                                         car_ui: true
                                         notification_icon: mdi:alert-circle
@@ -1269,11 +1231,16 @@ actions:
                                   - condition: template
                                     value_template: "{{ wait.trigger.id == 'vehicle_left' }}"
                                 sequence:
+                                  - alias: Get notification content
+                                    variables:
+                                      title_id: "itinerary_canceled"
+                                      message_id: "vehicle_left"
+                                      <<: *get_translation
                                   - alias: Notify driver of itinerary cancelation as he left vehicle
                                     action: "{{ notify_service }}"
                                     data:
-                                      title: !input itinerary_canceled_title
-                                      message: !input vehicle_left_message
+                                      title: "{{ title }}"
+                                      message: "{{ message }}"
                                       data:
                                         car_ui: true
                                         notification_icon: mdi:alert-circle
@@ -1353,11 +1320,16 @@ actions:
       value_template: "{{ is_state(person, [state_attr(gate_location, 'friendly_name'), states[gate_location].object_id])
         and states[travel_time_sensor].last_updated < now() - timedelta(minutes=5) }}"
     then:
+      - alias: Get notification content
+        variables:
+          title_id: "itinerary_canceled"
+          message_id: "travel_time_did_not_respond"
+          <<: *get_translation
       - alias: Notify driver that travel time integration did not respond
         action: "{{ notify_service }}"
         data:
-          title: !input itinerary_canceled_title
-          message: !input travel_time_did_not_respond
+          title: "{{ title }}"
+          message: "{{ message }}"
           data:
             car_ui: true
             notification_icon: mdi:alert-circle
@@ -1370,11 +1342,16 @@ actions:
             tag: itinerary-status
             timeout: 300
     else:
+      - alias: Get notification content
+        variables:
+          title_id: "itinerary_canceled"
+          message_id: "vehicle_left"
+          <<: *get_translation
       - alias: Send itinerary canceled notification to driver as he left vehicle
         action: "{{ notify_service }}"
         data:
-          title: !input itinerary_canceled_title
-          message: !input vehicle_left_message
+          title: "{{ title }}"
+          message: "{{ message }}"
           data:
             car_ui: true
             notification_icon: mdi:alert-circle

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -375,41 +375,41 @@ variables:
       title:
         itinerary_update: "Itinerary ℹ️"
         itinerary_canceled: "Itinerary canceled ❌"
-        awaiting: "Gate awaiting {{ awaiting_persons }} 💤"
+        awaiting: "Gate awaiting {awaiting_persons} 💤"
         disabled: "Automatic Gate disabled 🚫"
       message:
         itinerary_started: "Your itinerary has been started"
         awaiting: "The gate will close once all users have entered/exited"
         vehicle_left: "You have left your vehicle"
-        did_not_leave: "The vehicle did not leave in less than {{ safety_delay }} minutes"
-        did_not_arrive: "The vehicle did not arrive in less than {{ safety_delay }} minutes"
-        timed_out: "Your position has not been updated in {{ timeout_delay }} minutes"
+        did_not_leave: "The vehicle did not leave in less than {safety_delay} minutes"
+        did_not_arrive: "The vehicle did not arrive in less than {safety_delay} minutes"
+        timed_out: "Your position has not been updated in {timeout_delay} minutes"
         vehicle_away: "The vehicle is not in the activation zone"
         travel_time_did_not_respond: "Your travel time integration did not respond during your itinerary"
         not_home: "You were not detected at home"
         triggered_frequently: "The blueprint is being triggered repeatedly !"
         disabled_triggered_frequently: |-
-          The blueprint has been triggered {{ consecutive_errors }} times in a row
+          The blueprint has been triggered {consecutive_errors} times in a row
           Please enable the blueprint manually once the issue has been fixed
     fr:
       title:
         itinerary_update: "Itinéraire ℹ️"
         itinerary_canceled: "Itinéraire annulé ❌"
-        awaiting: "Portail en attente de {{awaiting_persons}} 💤"
+        awaiting: "Portail en attente de {awaiting_persons} 💤"
         disabled: "Automatic Gate désactivé 🚫"
       message:
         itinerary_started: "L'itinéraire a démarré"
         awaiting: "Le portail se refermera une fois tous les conducteurs entrés/sortis"
         vehicle_left: "Le véhicule a été arrêté"
-        did_not_leave: "Le véhicule n'est pas sorti en moins de {{ safety_delay }} minutes"
-        did_not_arrive: "Le véhicule n'est pas arrivé en moins de {{ safety_delay }} minutes"
-        timed_out: "Votre position n'a pas été mise à jour ces {{ timeout_delay }} dernières minutes"
+        did_not_leave: "Le véhicule n'est pas sorti en moins de {safety_delay} minutes"
+        did_not_arrive: "Le véhicule n'est pas arrivé en moins de {safety_delay} minutes"
+        timed_out: "Votre position n'a pas été mise à jour ces {timeout_delay} dernières minutes"
         vehicle_away: "Le véhicule n'est pas dans la zone d'ouverture"
         travel_time_did_not_respond: "Votre intégration de temps de trajet n'a pas renvoyé de valeur"
         not_home: "Le véhicule n'est pas à la maison"
         triggered_frequently: "L'automatisation se déclenche à répétition !"
         disabled_triggered_frequently: |-
-          L'automation s'est déclenchée {{ consecutive_errors }} fois d'affilée
+          L'automation s'est déclenchée {consecutive_errors} fois d'affilée
           Réactivez l'automatisation manuellement une fois le problème corrigé
 
 triggers:
@@ -474,7 +474,7 @@ actions:
                 variables: &get_translation
                   title_id: "itinerary_canceled"
                   message_id: "triggered_frequently"
-                  title: |-
+                  title_string: |-
                     {# Custom translation #}
                     {%
                       if 'title' in custom_translations_json
@@ -490,7 +490,13 @@ actions:
                     {% else %}
                       {{ strings['en']['title'][title_id] }}
                     {% endif %}
-                  message: |-
+                  title: |-
+                    {{
+                      title_string.format(
+                        awaiting_persons=awaiting_persons
+                      )
+                    }}
+                  message_string: |-
                     {# Custom translation #}
                     {%
                       if 'message' in custom_translations_json
@@ -506,6 +512,14 @@ actions:
                     {% else %}
                       {{ strings['en']['message'][message_id] }}
                     {% endif %}
+                  message: |-
+                    {{
+                      message_string.format(
+                        safety_delay=safety_delay,
+                        timeout_delay=timeout_delay,
+                        consecutive_errors=consecutive_errors
+                      )
+                    }}
               - alias: Notify driver that the blueprint is being triggered frequently
                 action: "{{ notify_service }}"
                 data:

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -375,7 +375,7 @@ variables:
       title:
         itinerary_update: "Itinerary ℹ️"
         itinerary_canceled: "Itinerary canceled ❌"
-        awaiting: "Gate awaiting {awaiting_persons} 💤"
+        awaiting: "Gate awaiting {awaited_persons} 💤"
         disabled: "Automatic Gate disabled 🚫"
       message:
         itinerary_started: "Your itinerary has been started"
@@ -395,7 +395,7 @@ variables:
       title:
         itinerary_update: "Itinéraire ℹ️"
         itinerary_canceled: "Itinéraire annulé ❌"
-        awaiting: "Portail en attente de {awaiting_persons} 💤"
+        awaiting: "Portail en attente de {awaited_persons} 💤"
         disabled: "Automatic Gate désactivé 🚫"
       message:
         itinerary_started: "L'itinéraire a démarré"
@@ -493,7 +493,7 @@ actions:
                   title: |-
                     {{
                       title_string.format(
-                        awaiting_persons=awaiting_persons
+                        awaited_persons=awaited_persons
                       )
                     }}
                   message_string: |-
@@ -858,16 +858,16 @@ actions:
             else:
               - alias: Get names of awaited persons
                 variables:
-                  awaiting_persons: |-
-                    {% set data = namespace(awaiting_persons=[]) %}
+                  awaited_persons: |-
+                    {% set data = namespace(awaited_persons=[]) %}
 
                     {% for sensor_idx in range(itinerary_sensors | length) %}
                       {% if sensor_idx != idx and is_state(itinerary_sensors[sensor_idx], ['on_approach', 'leaving']) %}
-                        {% set data.awaiting_persons = data.awaiting_persons + [state_attr(persons[sensor_idx], 'friendly_name')] %}
+                        {% set data.awaited_persons = data.awaited_persons + [state_attr(persons[sensor_idx], 'friendly_name')] %}
                       {% endif %}
                     {% endfor %}
 
-                    {{ data.awaiting_persons | join(', ') }}
+                    {{ data.awaited_persons | join(', ') }}
               - alias: Get notification translation
                 variables:
                   title_id: "awaiting"
@@ -1205,16 +1205,16 @@ actions:
                         then:
                           - alias: Get names of awaited persons
                             variables:
-                              awaiting_persons: |-
-                                {% set data = namespace(awaiting_persons=[]) %}
+                              awaited_persons: |-
+                                {% set data = namespace(awaited_persons=[]) %}
 
                                 {% for sensor_idx in range(itinerary_sensors | length) %}
                                   {% if sensor_idx != idx and is_state(itinerary_sensors[sensor_idx], ['on_approach', 'leaving']) %}
-                                    {% set data.awaiting_persons = data.awaiting_persons + [state_attr(persons[sensor_idx], 'friendly_name')] %}
+                                    {% set data.awaited_persons = data.awaited_persons + [state_attr(persons[sensor_idx], 'friendly_name')] %}
                                   {% endif %}
                                 {% endfor %}
 
-                                {{ data.awaiting_persons | join(', ') }}
+                                {{ data.awaited_persons | join(', ') }}
                           - alias: Get notification translation
                             variables:
                               title_id: "awaiting"

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -249,6 +249,7 @@ blueprint:
             language:
               languages:
                 - en
+                - fr
 
     optional_sensors:
       name: Optional sensors
@@ -376,6 +377,32 @@ variables:
         disabled_triggered_frequently: |-
           The blueprint has been triggered {{ consecutive_errors }} times in a row
           Please enable the blueprint manually once the issue has been fixed
+    fr:
+      title:
+        itinerary_update: "Itinéraire ℹ️"
+        itinerary_canceled: "Itinéraire annulé ❌"
+        awaiting: "Portail en attente de {{awaiting_persons}} 💤"
+        disabled: "Automatic Gate désactivé 🚫"
+      message:
+        itinerary_started: "L'itinéraire a démarré"
+        awaiting: "Le portail se refermera une fois tous les conducteurs entrés/sortis"
+        vehicle_left: "Le véhicule a été arrêté"
+        did_not_leave: "Le véhicule n'est pas sorti en moins de {{ safety_delay }} minutes"
+        did_not_arrive: "Le véhicule n'est pas arrivé en moins de {{ safety_delay }} minutes"
+        timed_out: "Votre position n'a pas été mise à jour ces {{ timeout_delay }} dernières minutes"
+        vehicle_away: "Le véhicule n'est pas dans la zone d'ouverture"
+        travel_time_did_not_respond: "Votre intégration de temps de trajet n'a pas renvoyé de valeur"
+        not_home: "Le véhicule n'est pas à la maison"
+        triggered_frequently: "L'automatisation se déclenche à répétition !"
+        disabled_triggered_frequently: |-
+          L'automation s'est déclenchée {{ consecutive_errors }} fois d'affilée
+          Réactivez l'automatisation manuellement une fois le problème corrigé
+
+    timed_out_message: La position a mis trop de temps à se rafraîchir
+    vehicle_away_message:
+    travel_time_did_not_respond:
+
+
 
 triggers:
   - alias: Trigger when user connects to vehicle

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -239,11 +239,10 @@ blueprint:
       name: Notification settings
       icon: mdi:bell
       collapsed: true
-      description: |-
-        Notification settings to translate texts or change notification behavior
       input:
         language:
           name: Notification language
+          description: The language in which notifications will be sent to you
           default: "en"
           selector:
             language:

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -249,6 +249,17 @@ blueprint:
               languages:
                 - en
                 - fr
+        custom_translations:
+          name: Custom translations
+          description: A json dictionary containing custom notification translations
+          default: |-
+            {
+              "title": {},
+              "message": {}
+            }
+          selector:
+            text:
+              multiline: true
 
     optional_sensors:
       name: Optional sensors
@@ -348,6 +359,8 @@ variables:
   eta_zone: !input eta_zone
   activation_zone: !input activation_zone
   language: !input language
+  custom_translations: !input custom_translations
+  custom_translations_json: "{{ custom_translations | from_json }}"
   ble_entities: !input ble_entities
   ble_scanner_switch: !input ble_scanner_switch
   ble_transmitter_entities: !input ble_transmitter_entities
@@ -466,14 +479,34 @@ actions:
                   title_id: "itinerary_canceled"
                   message_id: "triggered_frequently"
                   title: |-
-                    {% if title_id in strings[language]['title'] %}
+                    {# Custom translation #}
+                    {%
+                      if 'title' in custom_translations_json
+                      and title_id in custom_translations_json['title']
+                    %}
+                      {{ custom_translations_json['title'][title_id] }}
+
+                    {# Selected language #}
+                    {% elif title_id in strings[language]['title'] %}
                       {{ strings[language]['title'][title_id] }}
+
+                    {# Fallback to english #}
                     {% else %}
                       {{ strings['en']['title'][title_id] }}
                     {% endif %}
                   message: |-
-                    {% if message_id in strings[language]['message'] %}
+                    {# Custom translation #}
+                    {%
+                      if 'message' in custom_translations_json
+                      and message_id in custom_translations_json['message']
+                    %}
+                      {{ custom_translations_json['message'][message_id] }}
+
+                    {# Selected language #}
+                    {% elif message_id in strings[language]['message'] %}
                       {{ strings[language]['message'][message_id] }}
+
+                    {# Fallback to english #}
                     {% else %}
                       {{ strings['en']['message'][message_id] }}
                     {% endif %}

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -242,7 +242,7 @@ blueprint:
       input:
         language:
           name: Notification language
-          description: The language in which notifications will be sent to you
+          description: The **language** in which **notifications** will be sent to you
           default: "en"
           selector:
             language:
@@ -251,7 +251,9 @@ blueprint:
                 - fr
         custom_translations:
           name: Custom translations
-          description: A json dictionary containing custom notification translations
+          description: |-
+            A **json** dictionary to change the default **notifications translations**
+            *Note : You can find the translation keys in the strings['en'] variable in the code or in your traces*
           default: |-
             {
               "title": {},


### PR DESCRIPTION
Instead of relying on the user to translate each notification, let him select his language from a drop-down menu.
Also, add a json dictionnary input to let the user edit them if needed.
PRs to add new languages are welcome !