### PR TITLE
Fix travel_time_did_not_respond error not being raised

### DIFF
--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -1610,10 +1610,10 @@ actions:
                 then:
                   - alias: Update travel time
                     sequence: *update_travel_time
-              - alias: If the travel time sensor is not unknown
+              - alias: If the travel time sensor is not unknown or unavailable
                 if:
                   - condition: template
-                    value_template: "{{ states(travel_time_sensor) != 'unknown' }}"
+                    value_template: "{{ states(travel_time_sensor) in ['unknown', 'unavailable'] }}"
                 then:
                   - alias: Convert travel time to seconds
                     variables:

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -1610,11 +1610,6 @@ actions:
                 then:
                   - alias: Update travel time
                     sequence: *update_travel_time
-                  - alias: Wait for travel time integration to refresh
-                    condition: template
-                    value_template: |-
-                        {{ states[travel_time_sensor].last_updated > now() - timedelta(seconds=5)
-                              and states[travel_time_sensor].last_changed > now() - timedelta(minutes=5) }}
               - alias: If the travel time sensor is not unknown
                 if:
                   - condition: template
@@ -1732,8 +1727,11 @@ actions:
   - alias: If vehicle left in gate zone and travel time was not updated
     if:
       condition: template
-      value_template: "{{ is_state(person, [state_attr(gate_location, 'friendly_name'), states[gate_location].object_id])
-        and states[travel_time_sensor].last_updated < now() - timedelta(minutes=5) }}"
+      value_template: |-
+        {{
+          is_state(person, [state_attr(gate_location, 'friendly_name'), states[gate_location].object_id])
+          and opening_time is none
+        }}
     then:
       - alias: Set error id
         variables:


### PR DESCRIPTION
If the sensor fails to update, it returns unknown, but it still gets updated. Previous checks did not work