### PR TITLE
Change default departure closing behavior to timer

### DIFF
--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -216,7 +216,7 @@ blueprint:
               - **Cancelable timer** : A notification of a cancelable timer will be sent before opening your gate
               - **Notification request** : An actionable notification will be sent to close your gate
               - **Disabled** : Your gate won't close automatically
-          default: "notif"
+          default: "timer"
           selector:
             select:
               options:


### PR DESCRIPTION
If the user leaves without closing his gate, it should close after a while even if the user didn't see the notification.