### PR TITLE
Revert commit #3152cc8bad040692227ad79de30871463d751d46

### DIFF
--- a/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
+++ b/Automatic Gate/Extra/Automations/itinerary-tracker-notification.yaml
@@ -259,7 +259,7 @@ actions:
     variables:
       idx: "{{ driving_sensors.index(trigger.entity_id) }}"
       notify_services: |-
-        {% set devices_list = [] %}
+        {% set data = namespace(devices_list=[]) %}
 
           {% for notify_idx in range(notify_devices | length) %}
             {% if notify_idx != idx %}
@@ -279,12 +279,12 @@ actions:
                   and notify_idx < driving_sensors | length
                   and is_state(driving_sensors[notify_idx], 'on')
               %}
-                {% set devices_list = devices_list | union([notify_devices[notify_idx]]) %}
+                {% set data.devices_list = data.devices_list + [notify_devices[notify_idx]] %}
               {% endif %}
             {% endif %}
           {% endfor %}
 
-        {{ devices_list | map('device_attr', 'name') | map('slugify') | map('regex_replace', '^', 'notify.mobile_app_') | list }}
+        {{ data.devices_list | map('device_attr', 'name') | map('slugify') | map('regex_replace', '^', 'notify.mobile_app_') | list }}
 
       driving_sensor: "{{ driving_sensors[idx] }}"
       driver: "{{ persons[idx] }}"

--- a/Automatic Gate/automatic-gate.yaml
+++ b/Automatic Gate/automatic-gate.yaml
@@ -1022,7 +1022,7 @@ actions:
                             - "open"
                             - "cancel"
                           buttons: |-
-                            {% set buttons = [] %}
+                            {% set data = namespace(buttons=[]) %}
                             {% for button_id in button_ids %}
                               {# Custom translation #}
                               {%
@@ -1040,10 +1040,10 @@ actions:
                                 {% set translation = strings['en']['button'][button_id] %}
                               {% endif %}
 
-                              {% set buttons = buttons | union(translation) %}
+                              {% set data.buttons = data.buttons + [translation] %}
 
                             {% endfor %}
-                            {{ buttons }}
+                            {{ data.buttons }}
                       - alias: Ask the user if he wants to open the gate
                         action: "{{ notify_service }}"
                         data:
@@ -1416,7 +1416,7 @@ actions:
                       - alias: Get names of awaited persons
                         variables:
                           awaited_persons: |-
-                            {% set awaited_persons = [] %}
+                            {% set data = namespace(awaited_persons=[]) %}
 
                             {% for sensor_idx in range(itinerary_sensors | length) %}
                               {%
@@ -1424,14 +1424,14 @@ actions:
                                 and is_state(itinerary_sensors[sensor_idx], ['on_approach', 'leaving'])
                               %}
                                 {%
-                                  set awaited_persons = awaited_persons | union(
-                                    [state_attr(persons[sensor_idx], 'friendly_name')]
-                                  )
+                                  set data.awaited_persons = data.awaited_persons + [
+                                    state_attr(persons[sensor_idx], 'friendly_name')
+                                  ]
                                 %}
                               {% endif %}
                             {% endfor %}
 
-                            {{ awaited_persons | join(', ') }}
+                            {{ data.awaited_persons | join(', ') }}
                       - alias: Set notification ids
                         variables:
                           title_id: "awaiting"


### PR DESCRIPTION
Variables are still local in jinja loops.
This previous commit was breaking itinerary tracker notifications, awaited persons, and notification buttons