### PR TITLE
Fix notification chronometer

### DIFF
--- a/Automatic Gate/Extra/Automations/gate-alerts.yaml
+++ b/Automatic Gate/Extra/Automations/gate-alerts.yaml
@@ -432,7 +432,7 @@ actions:
                       43200
                     {% endif %}
                   chronometer: "{{ notification_delay != 0 }}"
-                  when: "{{ (utcnow() - timedelta(minutes=7)) | as_timestamp | int }}"
+                  when: "{{ (utcnow() - timedelta(minutes=notification_delay)) | as_timestamp | int }}"
                   actions: |-
                     {% if notification_type == 'open' %}
                       {{ [{'action': closing_order_id, 'title': button_text}] }}


### PR DESCRIPTION
The notification chronometer was always showing the gate opened for 7 minutes, even if the notification delay was changed