### PR TITLE
Make card only visible while driving

### DIFF
--- a/Dashboards/Vehicle-Tracker-Map/vehicle-tracker-map.yaml
+++ b/Dashboards/Vehicle-Tracker-Map/vehicle-tracker-map.yaml
@@ -21,13 +21,11 @@ sections:
 
       # EDIT: Duplicate this card as many times as you have drivers set in Automatic Gate
       - type: custom:mushroom-template-card
-        # Show the ETA only if someone is driving home
+        # Show the ETA only if someone is driving
         visibility:
-            - condition: state
-              entity: input_text.user0_itinerary # EDIT
-              state:
-                - arriving
-                - on_approach
+          - condition: state
+            entity: sensor.user0_driving_sensor # EDIT
+            state: on
         # Estimated time remaining
         primary: >-
           {# EDIT #}


### PR DESCRIPTION
Previously the visibility was relying on the itinerary sensor. However, the visibility does not support templates, and the new itinerary sensor stores data in json format. For now, we should simply use the driving sensor.