### PR TITLE
Remove left over trigger

### DIFF
--- a/Blueprints/Gate-Alerts/gate-alerts.yaml
+++ b/Blueprints/Gate-Alerts/gate-alerts.yaml
@@ -279,16 +279,6 @@ triggers:
     for:
       minutes: !input notification_delay
     enabled: "{{ notification_type == 'close' }}"
-  - trigger: state
-    entity_id: !input gate
-    to:
-      - "closed"
-    not_from:
-      - "unknown"
-      - "unavailable"
-    for:
-      minutes: !input notification_delay
-    enabled: "{{ notification_type == 'close' and states[gate].domain == 'cover' and state_attr(gate, 'supported_features') | bitwise_and(4) == 0 }}"
 
   - alias: Wait for error
     trigger: state


### PR DESCRIPTION
A previous trigger from the test phase was left over, but was displaying an error in the logs.