### PR TITLE
Fix notification received when wait trigger timeout runs out on departure

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -1213,11 +1213,13 @@ actions:
           closing_behavior: !input departure_closing_behavior
           opening_message: "leaving_home"
           timeout_messages: |-
-            dict(
-              timeout_messages, **{
-                'safety_delay': 'did_not_leave'
-              }
-            )
+            {{
+              dict(
+                timeout_messages, **{
+                  'safety_delay': 'did_not_leave'
+                }
+              )
+            }}
       - alias: Open and close gate by following behaviors set by the user
         sequence: &open_close_behavior
           - alias: Initialize a variable to wait for the phone to receive the notification before starting the timer


### PR DESCRIPTION
The timeout_messages dict was replaced by a string due to missing jinja2 beacons