### PR TITLE
Fix checks warning when disabled

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -1158,6 +1158,10 @@ actions:
       - alias: Confirm that no error occured while the config checker was running
         variables:
           successful_check: true
+    else:
+      - alias: Mark the check as successful since it did not happen
+        variables:
+          successful_check: true
     continue_on_error: true
   - alias: If an error occured while the config checker was running
     if:

--- a/Blueprints/Gate-Alerts/gate-alerts.yaml
+++ b/Blueprints/Gate-Alerts/gate-alerts.yaml
@@ -492,6 +492,10 @@ actions:
       - alias: Confirm that no error occured while the config checker was running
         variables:
           successful_check: true
+    else:
+      - alias: Mark the check as successful since it did not happen
+        variables:
+          successful_check: true
     continue_on_error: true
   - alias: If an error occured while the config checker was running
     if:

--- a/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
+++ b/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
@@ -560,6 +560,10 @@ actions:
       - alias: Confirm that no error occured while the config checker was running
         variables:
           successful_check: true
+    else:
+      - alias: Mark the check as successful since it did not happen
+        variables:
+          successful_check: true
     continue_on_error: true
   - alias: If an error occured while the config checker was running
     if:


### PR DESCRIPTION
When no tests had to be run, they were considered unsuccessful and were raising an error