### PR TITLE
Apply changes made to the gate to the LivingColors firmware

### DIFF
--- a/ESPHome-Firmwares/Philips-LivingColors/livingcolors.yaml
+++ b/ESPHome-Firmwares/Philips-LivingColors/livingcolors.yaml
@@ -1,8 +1,11 @@
 esphome:
   name: philips-livingcolors
   friendly_name: Philips LivingColors
-  platform: esp32
-  board: esp32dev #ESP32-WROOM-32 (version printed on the chip)
+
+esp32:
+  board: esp32dev #ESP32-WROOM-32E (version printed on the chip)
+  framework:
+    type: esp-idf
 
 # Enable logging
 logger:

--- a/ESPHome-Firmwares/Philips-LivingColors/livingcolors.yaml
+++ b/ESPHome-Firmwares/Philips-LivingColors/livingcolors.yaml
@@ -60,7 +60,7 @@ light:
   # Fake light component to simulate a led strip
   - platform: partition
     id: livingcolors
-    name: Philips LivingColors
+    name: None
     segments:
       - single_light_id: base_light
     effects:


### PR DESCRIPTION
* Fix compilation on latest ESPHome version
* Remove the name being displayed twice on the light entity