### PR TITLE
Remove the WLED lighting protocol from livingcolors.yaml

### DIFF
--- a/ESPHome-Firmwares/Philips-LivingColors/README.md
+++ b/ESPHome-Firmwares/Philips-LivingColors/README.md
@@ -4,7 +4,7 @@
 
 A simple ESPHome configuration to hack a Philips LivingColors Mini with an ESP32
 
-Has both E1.31 and WLED protocols enabled by default for lighting software control (e.g.: [Artemis](https://github.com/Artemis-RGB/Artemis))
+Has the E1.31 protocol enabled by default for lighting software control (e.g.: [Artemis](https://github.com/Artemis-RGB/Artemis))
 
 
 ## Buy Me a Coffee ☕

--- a/ESPHome-Firmwares/Philips-LivingColors/livingcolors.yaml
+++ b/ESPHome-Firmwares/Philips-LivingColors/livingcolors.yaml
@@ -33,9 +33,6 @@ wifi:
 e131:
   method: unicast
 
-# Enable wled lighting protocol
-wled:
-
 # Each led GPIO address
 output:
   - platform: ledc
@@ -71,4 +68,3 @@ light:
       - e131:
           universe: 1
           channels: RGB
-      - wled:


### PR DESCRIPTION
The WLED protocol is only supported on the arduino platform, which is being replaced by esp-idf.
You should use the E1.31 protocol instead.