### PR TITLE
Change open-when-connected-to input id

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -67,7 +67,7 @@ blueprint:
             entity:
               filter:
                 domain: zone
-        open_when_connected_to:
+        arrival_opening_method:
           name: 🔓 Gate opening method on arrival
           description: |-
             The sensor you want to use do detect your arrival and open your gate
@@ -656,7 +656,7 @@ variables:
   itinerary_started_notif: !input itinerary_started_notif
   wifi_devices: !input wifi_devices
   forbidden_zones: !input forbidden_zones
-  open_when_connected_to: !input open_when_connected_to
+  arrival_opening_method: !input arrival_opening_method
   dont_lock_if_people_remaining: !input dont_lock_if_people_remaining
   quick_tt_updates: 0
   last_quick_tt_update: "{{ none }}"
@@ -957,7 +957,7 @@ actions:
                   (
                     'ble' in (
                       only_open_near
-                      + [open_when_connected_to]
+                      + [arrival_opening_method]
                       + close_when_disconnected_from
                     )
                     or ble_transmitter_entities | length > 0
@@ -973,7 +973,7 @@ actions:
                   if ble_entities | length > 0 and (
                     'ble' not in (
                       only_open_near
-                      + [open_when_connected_to]
+                      + [arrival_opening_method]
                       + close_when_disconnected_from
                     )
                   )
@@ -1060,7 +1060,7 @@ actions:
             - alias: Check that the user has a travel time sensor for his arrival
               error: |-
                 {{
-                  open_when_connected_to == 'time'
+                  arrival_opening_method == 'time'
                   and travel_time_sensors | length != persons | length
                 }}
               message_id: "missing_travel_time_sensors"
@@ -1068,7 +1068,7 @@ actions:
             - alias: Check that the activation zone is not too large
               error: |-
                 {{
-                  open_when_connected_to == 'zone'
+                  arrival_opening_method == 'zone'
                   and activation_zone > 400
                 }}
               message_id: "zone_too_large"
@@ -3410,7 +3410,7 @@ actions:
             - alias: If the opening method should use a BLE tracker
               conditions:
                 - condition: template
-                  value_template: "{{ open_when_connected_to == 'ble' }}"
+                  value_template: "{{ arrival_opening_method == 'ble' }}"
               sequence:
                 - alias: Set an empty trigger id
                   variables: *reset_trigger_id
@@ -3473,7 +3473,7 @@ actions:
             - alias: If the opening method should use a travel time sensor
               conditions:
                 - condition: template
-                  value_template: "{{ open_when_connected_to == 'time' }}"
+                  value_template: "{{ arrival_opening_method == 'time' }}"
               sequence:
                 - alias: Repeat while driver in activation zone and still driving
                   # This allows to update to a precise ETA even if a traffic jam appears near your gate
@@ -3624,12 +3624,12 @@ actions:
           condition: template
           value_template: |-
             {{
-              open_when_connected_to == 'ble'
+              arrival_opening_method == 'ble'
                 and wait.trigger.id == 'ble_in_reach'
-              or open_when_connected_to == 'time'
+              or arrival_opening_method == 'time'
                 and opening_time is not none
                 and opening_time <= as_timestamp(now())
-              or open_when_connected_to == 'zone'
+              or arrival_opening_method == 'zone'
             }}
         - alias: Return to the previous loop if the user has left the the activation zone
           condition: template
@@ -3676,7 +3676,7 @@ actions:
               states[gate_location].object_id
             ]
           )
-          and 'time' in open_when_connected_to
+          and 'time' in arrival_opening_method
           and opening_time is none
         %}
           travel_time_did_not_respond


### PR DESCRIPTION
Users of previous dev versions had the default value set to []. The new version expected a string, not a list, and blocked the opening on arrival.