### PR TITLE
Paralellize actions when possible

### DIFF
--- a/Blueprints/Gate-Alerts/gate-alerts.yaml
+++ b/Blueprints/Gate-Alerts/gate-alerts.yaml
@@ -713,172 +713,174 @@ actions:
           - alias: Format the notification message
             variables:
               message: "{{ message.format(error=error) }}"
-      - alias: Notify each user
-        repeat:
-          for_each: "{{ notify_services }}"
-          sequence:
-            - action: "{{ repeat.item }}"
-              data:
-                title: "{{ title }}"
-                message: "{{ message }}"
-                data:
-                  car_ui: "{{ car_visible }}"
-                  notification_icon: mdi:gate-alert
-                  channel: Gate alerts
-                  importance: high
-                  priority: high
-                  ttl: 0
-                  sticky: true
-                  persistent: "{{ notification_type == 'open' }}"
-                  push:
-                    sound:
-                      name: "default"
-                      critical: "{{ int(car_visible) }}"
-                  tag: "{{ notification_tag }}"
-                  timeout: |-
-                    {% if notification_type == 'error' or is_state(gate, ['off', 'closed']) %}
-                      30
-                    {% else %}
-                      2147483647
-                    {% endif %}
-                  chronometer: "{{ notification_delay != 0 }}"
-                  when: "{{ (utcnow() - timedelta(minutes=notification_delay)) | as_timestamp | int }}"
-                  actions: |-
-                    {%
-                      if notification_type == 'open'
-                      and states[gate].domain in ['cover', 'switch']
-                    %}
-                      {{
-                        [
-                          {
-                            'action': closing_order_id,
-                            'title': button_text,
-                            'icon': 'sfsymbols:lock'
-                          }
-                        ]
-                      }}
-                    {% else %}
-                      {{ [] }}
-                    {% endif %}
 
-            - alias: Play TTS on each phone, if enabled
-              if:
-                condition: template
-                value_template: !input phone_tts
-              then:
+      - parallel:
+          - alias: Notify each user
+            repeat:
+              for_each: "{{ notify_services }}"
+              sequence:
                 - action: "{{ repeat.item }}"
                   data:
-                    message: TTS
+                    title: "{{ title }}"
+                    message: "{{ message }}"
                     data:
-                      tts_text: "{{ message }}"
+                      car_ui: "{{ car_visible }}"
+                      notification_icon: mdi:gate-alert
                       channel: Gate alerts
                       importance: high
                       priority: high
                       ttl: 0
-                      media_stream: !input phone_tts_stream
+                      sticky: true
+                      persistent: "{{ notification_type == 'open' }}"
+                      push:
+                        sound:
+                          name: "default"
+                          critical: "{{ int(car_visible) }}"
+                      tag: "{{ notification_tag }}"
+                      timeout: |-
+                        {% if notification_type == 'error' or is_state(gate, ['off', 'closed']) %}
+                          30
+                        {% else %}
+                          2147483647
+                        {% endif %}
+                      chronometer: "{{ notification_delay != 0 }}"
+                      when: "{{ (utcnow() - timedelta(minutes=notification_delay)) | as_timestamp | int }}"
+                      actions: |-
+                        {%
+                          if notification_type == 'open'
+                          and states[gate].domain in ['cover', 'switch']
+                        %}
+                          {{
+                            [
+                              {
+                                'action': closing_order_id,
+                                'title': button_text,
+                                'icon': 'sfsymbols:lock'
+                              }
+                            ]
+                          }}
+                        {% else %}
+                          {{ [] }}
+                        {% endif %}
 
-      - alias: If the user has entered a TTS service
-        if:
-          - condition: template
-            value_template: "{{ speaker_tts_service != '' }}"
-        then:
-          - alias: Play TTS on each speaker
-            repeat:
-              for_each: "{{ speaker_tts_devices }}"
-              sequence:
-                - alias: Initialize a variable to store the speaker volume later
-                  variables:
-                    old_volume: "{{ none }}"
-
-                - alias: If the tts night mode is currently active
+                - alias: Play TTS on each phone, if enabled
                   if:
-                    - condition: template
-                      value_template: |-
-                        {% set start = today_at(tts_volume_night_time_start) %}
-                        {% set end = today_at(tts_volume_night_time_end) %}
-                        {% set time = now() %}
-                        {{
-                          tts_volume_night_time_start != ''
-                          and tts_volume_night_time_end != ''
-                          and (
-                            start <= end and start <= time <= end
-                            or start > end and (time >= start or time <= end)
-                          )
-                        }}
+                    condition: template
+                    value_template: !input phone_tts
                   then:
-                    - alias: If the speaker is not exposing its volume because it is turned off
+                    - action: "{{ repeat.item }}"
+                      data:
+                        message: TTS
+                        data:
+                          tts_text: "{{ message }}"
+                          channel: Gate alerts
+                          importance: high
+                          priority: high
+                          ttl: 0
+                          media_stream: !input phone_tts_stream
+
+          - alias: If the user has entered a TTS service
+            if:
+              - condition: template
+                value_template: "{{ speaker_tts_service != '' }}"
+            then:
+              - alias: Play TTS on each speaker
+                repeat:
+                  for_each: "{{ speaker_tts_devices }}"
+                  sequence:
+                    - alias: Initialize a variable to store the speaker volume later
+                      variables:
+                        old_volume: "{{ none }}"
+
+                    - alias: If the tts night mode is currently active
                       if:
                         - condition: template
                           value_template: |-
+                            {% set start = today_at(tts_volume_night_time_start) %}
+                            {% set end = today_at(tts_volume_night_time_end) %}
+                            {% set time = now() %}
                             {{
-                              is_state(repeat.item, 'off')
-                              and state_attr(repeat.item, 'volume_level') is none
+                              tts_volume_night_time_start != ''
+                              and tts_volume_night_time_end != ''
+                              and (
+                                start <= end and start <= time <= end
+                                or start > end and (time >= start or time <= end)
+                              )
                             }}
                       then:
-                        - alias: Turn on the speaker
-                          action: media_player.turn_on
+                        - alias: If the speaker is not exposing its volume because it is turned off
+                          if:
+                            - condition: template
+                              value_template: |-
+                                {{
+                                  is_state(repeat.item, 'off')
+                                  and state_attr(repeat.item, 'volume_level') is none
+                                }}
+                          then:
+                            - alias: Turn on the speaker
+                              action: media_player.turn_on
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - alias: Wait for the speaker to turn on
+                              wait_template: "{{ not is_state(repeat.item, 'off') }}"
+                              continue_on_timeout: true
+                              timeout: 3
+
+                        - alias: Only continue if the speaker has a higher volume than night mode
+                          condition: template
+                          value_template: |-
+                            {{
+                              state_attr(repeat.item, 'volume_level') is none
+                              or (
+                                state_attr(repeat.item, 'volume_level') * 100
+                              ) | int > tts_volume_at_night
+                            }}
+
+                        - alias: Save the current volume
+                          variables:
+                            old_volume: "{{ state_attr(repeat.item, 'volume_level') }}"
+
+                        - alias: Lower the volume
+                          action: media_player.volume_set
                           target:
                             entity_id: "{{ repeat.item }}"
-                        - alias: Wait for the speaker to turn on
-                          wait_template: "{{ not is_state(repeat.item, 'off') }}"
-                          continue_on_timeout: true
-                          timeout: 3
+                          data:
+                            volume_level: "{{ tts_volume_at_night / 100 }}"
 
-                    - alias: Only continue if the speaker has a higher volume than night mode
-                      condition: template
-                      value_template: |-
-                        {{
-                          state_attr(repeat.item, 'volume_level') is none
-                          or (
-                            state_attr(repeat.item, 'volume_level') * 100
-                          ) | int > tts_volume_at_night
-                        }}
-
-                    - alias: Save the current volume
-                      variables:
-                        old_volume: "{{ state_attr(repeat.item, 'volume_level') }}"
-
-                    - alias: Lower the volume
-                      action: media_player.volume_set
-                      target:
-                        entity_id: "{{ repeat.item }}"
+                    - alias: Play the TTS
+                      action: tts.speak
                       data:
-                        volume_level: "{{ tts_volume_at_night / 100 }}"
-
-                - alias: Play the TTS
-                  action: tts.speak
-                  data:
-                    cache: true
-                    media_player_entity_id: "{{ repeat.item }}"
-                    message: "{{ message }}"
-                  target:
-                    entity_id: "{{ speaker_tts_service }}"
-
-                - alias: If the old volume could be saved
-                  if:
-                    - condition: template
-                      value_template: "{{ old_volume is not none }}"
-                  then:
-                    - alias: Restore the old volume
-                      action: media_player.volume_set
+                        cache: true
+                        media_player_entity_id: "{{ repeat.item }}"
+                        message: "{{ message }}"
                       target:
-                        entity_id: "{{ repeat.item }}"
-                      data:
-                        volume_level: "{{ old_volume }}"
+                        entity_id: "{{ speaker_tts_service }}"
 
-      - alias: Send persistent notification to dashboard, if enabled
-        if:
-          condition: template
-          value_template: !input persistent_notification
-        then:
-          - action: persistent_notification.create
-            data:
-              title: "{{ title }}"
-              message: "{{ message }}"
-              notification_id: "{{ notification_tag }}"
+                    - alias: If the old volume could be saved
+                      if:
+                        - condition: template
+                          value_template: "{{ old_volume is not none }}"
+                      then:
+                        - alias: Restore the old volume
+                          action: media_player.volume_set
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                          data:
+                            volume_level: "{{ old_volume }}"
 
-      - alias: Exec user extra actions
-        sequence: !input extra_actions
+          - alias: Send persistent notification to dashboard, if enabled
+            if:
+              condition: template
+              value_template: !input persistent_notification
+            then:
+              - action: persistent_notification.create
+                data:
+                  title: "{{ title }}"
+                  message: "{{ message }}"
+                  notification_id: "{{ notification_tag }}"
+
+          - alias: Exec user extra actions
+            sequence: !input extra_actions
 
   - wait_for_trigger:
     - alias: Wait for gate closed

--- a/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
+++ b/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
@@ -718,492 +718,495 @@ actions:
   - alias: Format the notification message
     variables:
       message: "{{ message.format(driver_name=driver_name) }}"
-  - alias: Notify each user except the driver about itinerary start
-    repeat:
-      for_each: "{{ active_notify_services }}"
-      sequence:
-        - action: "{{ repeat.item }}"
-          data:
-            message: "{{ message }}"
-            data: &notification_data
-              notification_icon: mdi:car
-              tag: "{{ notification_tag }}"
-              channel: Itinerary status
-              sticky: true
-              # Hack to retrieve notification service when dismissed
-              confirmation: "{{ repeat.item }}"
-              url: !input on_tap_link
-              clickAction: !input on_tap_link
-              alert_once: true
-  - alias: Send an itinerary started persistent notification
-    action: persistent_notification.create
-    data:
-      message: "{{ message }}"
-      notification_id: "{{ persistent_id }}"
-    enabled: !input persistent_notification
-  - alias: If drive_start_tts is enabled
-    if:
-      - condition: template
-        value_template: !input drive_start_tts
-    then: &play_speaker_tts
-      - alias: Only continue if a TTS service has been entered and someone is home
-        condition: template
-        value_template: |-
-          {{
-            speaker_tts_service != ''
-            and persons | select('is_state', 'home') | list != []
-          }}
-      - alias: Play TTS on each speaker
+  - parallel:
+      - alias: Notify each user except the driver about itinerary start
         repeat:
-          for_each: "{{ speaker_tts_devices }}"
+          for_each: "{{ active_notify_services }}"
           sequence:
-            - alias: Initialize a variable to store the speaker volume later
-              variables:
-                old_volume: "{{ none }}"
-            - alias: If the tts night mode is currently active
-              if:
-                - condition: template
-                  value_template: |-
-                    {% set start = today_at(tts_volume_night_time_start) %}
-                    {% set end = today_at(tts_volume_night_time_end) %}
-                    {% set time = now() %}
-                    {{
-                      tts_volume_night_time_start != ''
-                      and tts_volume_night_time_end != ''
-                      and (
-                        start <= end and start <= time <= end
-                        or start > end and (time >= start or time <= end)
-                      )
-                    }}
-              then:
-                - alias: If the speaker is not exposing its volume because it is turned off
+            - action: "{{ repeat.item }}"
+              data:
+                message: "{{ message }}"
+                data: &notification_data
+                  notification_icon: mdi:car
+                  tag: "{{ notification_tag }}"
+                  channel: Itinerary status
+                  sticky: true
+                  # Hack to retrieve notification service when dismissed
+                  confirmation: "{{ repeat.item }}"
+                  url: !input on_tap_link
+                  clickAction: !input on_tap_link
+                  alert_once: true
+      - alias: Send an itinerary started persistent notification
+        action: persistent_notification.create
+        data:
+          message: "{{ message }}"
+          notification_id: "{{ persistent_id }}"
+        enabled: !input persistent_notification
+      - alias: If drive_start_tts is enabled
+        if:
+          - condition: template
+            value_template: !input drive_start_tts
+        then: &play_speaker_tts
+          - alias: Only continue if a TTS service has been entered and someone is home
+            condition: template
+            value_template: |-
+              {{
+                speaker_tts_service != ''
+                and persons | select('is_state', 'home') | list != []
+              }}
+          - alias: Play TTS on each speaker
+            repeat:
+              for_each: "{{ speaker_tts_devices }}"
+              sequence:
+                - alias: Initialize a variable to store the speaker volume later
+                  variables:
+                    old_volume: "{{ none }}"
+                - alias: If the tts night mode is currently active
                   if:
                     - condition: template
                       value_template: |-
+                        {% set start = today_at(tts_volume_night_time_start) %}
+                        {% set end = today_at(tts_volume_night_time_end) %}
+                        {% set time = now() %}
                         {{
-                          is_state(repeat.item, 'off')
-                          and state_attr(repeat.item, 'volume_level') is none
+                          tts_volume_night_time_start != ''
+                          and tts_volume_night_time_end != ''
+                          and (
+                            start <= end and start <= time <= end
+                            or start > end and (time >= start or time <= end)
+                          )
                         }}
                   then:
-                    - alias: Turn on the speaker
-                      action: media_player.turn_on
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                    - alias: Wait for the speaker to turn on
-                      wait_template: "{{ not is_state(repeat.item, 'off') }}"
-                      continue_on_timeout: true
-                      timeout: 3
-                - alias: Only continue if the speaker has a higher volume than night mode
-                  condition: template
-                  value_template: |-
-                    {{
-                      state_attr(repeat.item, 'volume_level') is none
-                      or (
-                        state_attr(repeat.item, 'volume_level') * 100
-                      ) | int > tts_volume_at_night
-                    }}
-                - alias: Save the current volume
-                  variables:
-                    old_volume: "{{ state_attr(repeat.item, 'volume_level') }}"
-                - alias: Lower the volume
-                  action: media_player.volume_set
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                  data:
-                    volume_level: "{{ tts_volume_at_night / 100 }}"
-            - alias: Play the TTS
-              action: tts.speak
-              data:
-                cache: true
-                media_player_entity_id: "{{ repeat.item }}"
-                message: "{{ message }}"
-              target:
-                entity_id: "{{ speaker_tts_service }}"
-            - alias: If the old volume could be saved
-              if:
-                - condition: template
-                  value_template: "{{ old_volume is not none }}"
-              then:
-                - alias: Restore the old volume
-                  action: media_player.volume_set
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                  data:
-                    volume_level: "{{ old_volume }}"
-  - alias: If travel time sensors set
-    if:
-      condition: template
-      value_template: "{{ travel_time_sensors != [] }}"
-    then:
-      - alias: Initialize variables for the following sequence
-        variables:
-          travel_time_sensor: "{{ travel_time_sensors[idx] }}"
-          next_refresh: 0
-          nearly_arrived_sent: false
-          last_arrival_timestamp: 0
-          nearly_arrived_timestamp: "{{ none }}"
-          arrival_timestamp: "{{ none }}"
-          timer_removed: false
-      - alias: Repeat while driver still driving
-        repeat:
-          while:
-            - condition: template
-              value_template: "{{ is_state(driving_sensor, 'on') }}"
-          sequence:
-            - alias: Wait for travel time update, vehicle left, or notification cleared
-              wait_for_trigger:
-                - trigger: event
-                  id: travel_time
-                  event_type: state_changed
-                  event_data:
-                    entity_id: "{{ travel_time_sensor }}"
-                - trigger: template
-                  id: vehicle_left
-                  value_template: "{{ is_state(driving_sensor, 'off') }}"
-                - trigger: event
-                  id: notification_cleared
-                  event_type: mobile_app_notification_cleared
-                  event_data:
-                    tag: "{{ notification_tag }}"
-                - trigger: persistent_notification
-                  id: persistent_cleared
-                  notification_id: "{{ persistent_id }}"
-                  update_type: removed
-                  enabled: "{{ persistent_active }}"
-                - trigger: template
-                  id: conditions_changed
-                  value_template: |-
-                    {% set data = namespace(services_list=[]) %}
-
-                    {% for notify_idx in range(notify_services | length) %}
-                      {% if notify_idx != idx and notify_idx not in dismissed_idx %}
-                        {% if notify_everyone
-                          or zones_to_notify
-                            and notify_idx < persons | length
-                            and is_state(persons[notify_idx],
-                              zones_to_notify | map('state_attr', 'friendly_name') | list
-                              + zones_to_notify | map('replace', 'zone.', '') | list
-                            )
-
-                          or notify_persons_away
-                            and notify_idx < persons | length
-                            and is_state(persons[notify_idx], 'not_home')
-
-                          or notify_persons_driving
-                            and notify_idx < driving_sensors | length
-                            and is_state(driving_sensors[notify_idx], 'on')
-                        %}
-                          {% set data.services_list = data.services_list + [notify_services[notify_idx]] %}
-                        {% endif %}
-                      {% endif %}
-                    {% endfor %}
-
-                    {{ data.services_list != active_notify_services }}
-                  enabled: "{{ not notify_everyone }}"
-              timeout:
-                # Wait for the end of the cooldown, or for the nearly arrived TTS, or indefinitely
-                seconds: |-
-                  {% set values = [2147483647] %}
-
-                  {# End of cooldown #}
-                  {% if next_refresh > now() | as_timestamp %}
-                    {% set values = values | union([next_refresh - now() | as_timestamp]) %}
-                  {% endif %}
-
-                  {# Nearly arrived TTS #}
-                  {%
-                    if nearly_arrived_tts
-                    and not nearly_arrived_sent
-                    and nearly_arrived_timestamp is not none
-                  %}
-                    {%
-                      set values = values | union(
-                        [
-                          nearly_arrived_timestamp - now() | as_timestamp
-                        ]
-                      )
-                    %}
-                  {% endif %}
-
-                  {# Remaining time reached zero #}
-                  {% if arrival_timestamp is not none and not timer_removed %}
-                    {%
-                      set values = values | union(
-                        [
-                          arrival_timestamp - now() | as_timestamp
-                        ]
-                      )
-                    %}
-                  {% endif %}
-
-                  {{ max(min(values), 0) }}
-            - choose:
-                - alias: If triggered by a mobile notification cleared
-                  conditions:
-                    - condition: template
-                      value_template: "{{ wait.trigger.id == 'notification_cleared' }}"
-                  sequence:
-                    - alias: Remove the notification service
-                      variables:
-                        active_notify_services: |-
-                          {{ active_notify_services | difference([wait.trigger.event.data.confirmation]) }}
-                        dismissed_idx: |-
-                          {{
-                            dismissed_idx | union(
-                              [
-                                notify_services.index(
-                                  wait.trigger.event.data.confirmation
-                                )
-                              ]
-                            )
-                          }}
-                - alias: If triggered by a persistent notification cleared
-                  conditions:
-                    - condition: template
-                      value_template: "{{ wait.trigger.id == 'persistent_cleared' }}"
-                  sequence:
-                    alias: Disable persistent notifications
-                    variables:
-                      persistent_active: false
-                - alias: If triggered by a notify condition change
-                  conditions:
-                    - condition: template
-                      value_template: "{{ wait.trigger.id == 'conditions_changed' }}"
-                  sequence:
-                    - variables:
-                        active_notify_services: *get_active_services
-                - alias: If travel time remaining needs to trigger nearly arrived TTS
-                  conditions:
-                    - condition: template
-                      value_template: |-
-                        {{ nearly_arrived_tts
-                          and not nearly_arrived_sent
-                          and nearly_arrived_timestamp is not none
-                          and nearly_arrived_timestamp <= now() | as_timestamp
-                          and speaker_tts_service != ''
-                        }}
-                  sequence:
-                    - alias: Get TTS translation
-                      variables:
-                        message_id: "nearly_arrived"
-                        message: *get_message
-                    - alias: Format the notification message
-                      variables:
-                        message: |-
-                          {{
-                            message.format(
-                              driver_name=driver_name,
-                              remaining_minutes=(
-                                (
-                                  arrival_timestamp
-                                  - now() | as_timestamp
-                                ) / 60
-                              ) | round
-                            )
-                          }}
-                    - sequence: *play_speaker_tts
-                    - alias: Mark nearly arrived TTS as already sent
-                      variables:
-                        nearly_arrived_sent: true
-                - alias: If triggered by travel time update and notifications are not on cooldown
-                  conditions:
-                    - condition: template
-                      value_template: |-
-                        {{
-                          wait.trigger.id == 'travel_time'
-                          and next_refresh <= now() | as_timestamp
-                        }}
-                  sequence:
-                    - alias: Calculate ETA
-                      variables:
-                        remaining: |-
-                            {% if state_attr(travel_time_sensor, 'duration') != none %}
-                              {{ state_attr(travel_time_sensor, 'duration') | float * 60 }}
-                            {% elif state_attr(travel_time_sensor, 'unit_of_measurement') == "min" %}
-                              {{ states(travel_time_sensor) | float * 60 }}
-                            {% elif state_attr(travel_time_sensor, 'unit_of_measurement') == "s" %}
-                              {{ states(travel_time_sensor) | float }}
-                            {% else %}
-                              {{ none }}
-                            {% endif %}
-                    - alias: Stop if travel time integration is not supported
-                      if:
-                        - condition: template
-                          value_template: "{{ remaining is none }}"
-                      then:
-                        - alias: Get notification translation
-                          variables:
-                            message_id: "unsupported_tt_integration"
-                            message: *get_message
-                        - alias: Notify all users on the dashboard that the integration is unsupported
-                          action: persistent_notification.create
-                          data:
-                            title: "{{ title }}"
-                            message: "{{ message }}"
-                            notification_id: "{{ persistent_id }}"
-                        - stop: Travel time integration not supported
-                          error: true
-                    - alias: Calculate next refresh
-                      variables:
-                        cooldown: !input notif_refresh_rate_ftn
-                        next_refresh: "{{ now() | as_timestamp + cooldown }}"
-                    - alias: Convert ETA to needed types
-                      variables:
-                        arrival_timestamp: "{{ as_timestamp(now()) + remaining }}"
-                        arrival: "{{ arrival_timestamp | timestamp_custom('%H:%M') }}"
-                    - alias: If the nearly arrived tts has not been triggered yet
+                    - alias: If the speaker is not exposing its volume because it is turned off
                       if:
                         - condition: template
                           value_template: |-
                             {{
-                              nearly_arrived_tts
-                              and not nearly_arrived_sent
+                              is_state(repeat.item, 'off')
+                              and state_attr(repeat.item, 'volume_level') is none
                             }}
                       then:
-                        - alias: Calculate the timestamp for the nearly arrived tts trigger
-                          variables:
-                            nearly_arrived_timestamp: "{{ arrival_timestamp - nearly_arrived_time*60 }}"
-                    - alias: Do not send notification if the time of arrival did not change
+                        - alias: Turn on the speaker
+                          action: media_player.turn_on
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                        - alias: Wait for the speaker to turn on
+                          wait_template: "{{ not is_state(repeat.item, 'off') }}"
+                          continue_on_timeout: true
+                          timeout: 3
+                    - alias: Only continue if the speaker has a higher volume than night mode
                       condition: template
                       value_template: |-
-                        {# If the next notification will be sent near the arrival #}
-                        {% if arrival_timestamp - next_refresh < 120 %}
-                          {# Refresh notification if eta differs by at least 5s #}
-                          {{
-                            (
-                              last_arrival_timestamp | int
-                              - arrival_timestamp | int
-                            ) | abs > 5
-                          }}
-                        {% else %}
-                          {# Refresh notification if eta differs by at least 1min #}
-                          {{
-                            (last_arrival_timestamp / 60) | int
-                            != (arrival_timestamp / 60) | int
-                          }}
-                        {% endif %}
-                    - alias: Save the current time of arrival
+                        {{
+                          state_attr(repeat.item, 'volume_level') is none
+                          or (
+                            state_attr(repeat.item, 'volume_level') * 100
+                          ) | int > tts_volume_at_night
+                        }}
+                    - alias: Save the current volume
                       variables:
-                        last_arrival_timestamp: "{{ arrival_timestamp }}"
-                    - alias: Get notification translation
-                      variables:
-                        message_id: "itinerary_ongoing"
-                        message: *get_message
-                    - alias: Format the notification message
-                      variables:
-                        message: |-
-                          {{
-                            message.format(
-                              arrival=arrival,
-                              driver_name=driver_name
-                            )
-                          }}
-                    - alias: Send ETA notification to each user
-                      repeat:
-                        for_each: "{{ active_notify_services }}"
-                        sequence:
-                          - action: "{{ repeat.item }}"
-                            data:
-                              message: "{{ message }}"
-                              data:
-                                <<: *notification_data
-                                notification_icon: mdi:map-marker-account
-                                chronometer: true
-                                when: "{{ arrival_timestamp | int }}"
-                    - alias: If persistent notifications are still active
-                      if:
-                        - condition: template
-                          value_template: "{{ persistent_active }}"
-                      then:
-                        - alias: Update the persistent notification
-                          action: persistent_notification.create
+                        old_volume: "{{ state_attr(repeat.item, 'volume_level') }}"
+                    - alias: Lower the volume
+                      action: media_player.volume_set
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        volume_level: "{{ tts_volume_at_night / 100 }}"
+                - alias: Play the TTS
+                  action: tts.speak
+                  data:
+                    cache: true
+                    media_player_entity_id: "{{ repeat.item }}"
+                    message: "{{ message }}"
+                  target:
+                    entity_id: "{{ speaker_tts_service }}"
+                - alias: If the old volume could be saved
+                  if:
+                    - condition: template
+                      value_template: "{{ old_volume is not none }}"
+                  then:
+                    - alias: Restore the old volume
+                      action: media_player.volume_set
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        volume_level: "{{ old_volume }}"
+      - sequence:
+          - alias: If travel time sensors set
+            if:
+              condition: template
+              value_template: "{{ travel_time_sensors != [] }}"
+            then:
+              - alias: Initialize variables for the following sequence
+                variables:
+                  travel_time_sensor: "{{ travel_time_sensors[idx] }}"
+                  next_refresh: 0
+                  nearly_arrived_sent: false
+                  last_arrival_timestamp: 0
+                  nearly_arrived_timestamp: "{{ none }}"
+                  arrival_timestamp: "{{ none }}"
+                  timer_removed: false
+              - alias: Repeat while driver still driving
+                repeat:
+                  while:
+                    - condition: template
+                      value_template: "{{ is_state(driving_sensor, 'on') }}"
+                  sequence:
+                    - alias: Wait for travel time update, vehicle left, or notification cleared
+                      wait_for_trigger:
+                        - trigger: event
+                          id: travel_time
+                          event_type: state_changed
+                          event_data:
+                            entity_id: "{{ travel_time_sensor }}"
+                        - trigger: template
+                          id: vehicle_left
+                          value_template: "{{ is_state(driving_sensor, 'off') }}"
+                        - trigger: event
+                          id: notification_cleared
+                          event_type: mobile_app_notification_cleared
+                          event_data:
+                            tag: "{{ notification_tag }}"
+                        - trigger: persistent_notification
+                          id: persistent_cleared
+                          notification_id: "{{ persistent_id }}"
+                          update_type: removed
+                          enabled: "{{ persistent_active }}"
+                        - trigger: template
+                          id: conditions_changed
+                          value_template: |-
+                            {% set data = namespace(services_list=[]) %}
+
+                            {% for notify_idx in range(notify_services | length) %}
+                              {% if notify_idx != idx and notify_idx not in dismissed_idx %}
+                                {% if notify_everyone
+                                  or zones_to_notify
+                                    and notify_idx < persons | length
+                                    and is_state(persons[notify_idx],
+                                      zones_to_notify | map('state_attr', 'friendly_name') | list
+                                      + zones_to_notify | map('replace', 'zone.', '') | list
+                                    )
+
+                                  or notify_persons_away
+                                    and notify_idx < persons | length
+                                    and is_state(persons[notify_idx], 'not_home')
+
+                                  or notify_persons_driving
+                                    and notify_idx < driving_sensors | length
+                                    and is_state(driving_sensors[notify_idx], 'on')
+                                %}
+                                  {% set data.services_list = data.services_list + [notify_services[notify_idx]] %}
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+
+                            {{ data.services_list != active_notify_services }}
+                          enabled: "{{ not notify_everyone }}"
+                      timeout:
+                        # Wait for the end of the cooldown, or for the nearly arrived TTS, or indefinitely
+                        seconds: |-
+                          {% set values = [2147483647] %}
+
+                          {# End of cooldown #}
+                          {% if next_refresh > now() | as_timestamp %}
+                            {% set values = values | union([next_refresh - now() | as_timestamp]) %}
+                          {% endif %}
+
+                          {# Nearly arrived TTS #}
+                          {%
+                            if nearly_arrived_tts
+                            and not nearly_arrived_sent
+                            and nearly_arrived_timestamp is not none
+                          %}
+                            {%
+                              set values = values | union(
+                                [
+                                  nearly_arrived_timestamp - now() | as_timestamp
+                                ]
+                              )
+                            %}
+                          {% endif %}
+
+                          {# Remaining time reached zero #}
+                          {% if arrival_timestamp is not none and not timer_removed %}
+                            {%
+                              set values = values | union(
+                                [
+                                  arrival_timestamp - now() | as_timestamp
+                                ]
+                              )
+                            %}
+                          {% endif %}
+
+                          {{ max(min(values), 0) }}
+                    - choose:
+                        - alias: If triggered by a mobile notification cleared
+                          conditions:
+                            - condition: template
+                              value_template: "{{ wait.trigger.id == 'notification_cleared' }}"
+                          sequence:
+                            - alias: Remove the notification service
+                              variables:
+                                active_notify_services: |-
+                                  {{ active_notify_services | difference([wait.trigger.event.data.confirmation]) }}
+                                dismissed_idx: |-
+                                  {{
+                                    dismissed_idx | union(
+                                      [
+                                        notify_services.index(
+                                          wait.trigger.event.data.confirmation
+                                        )
+                                      ]
+                                    )
+                                  }}
+                        - alias: If triggered by a persistent notification cleared
+                          conditions:
+                            - condition: template
+                              value_template: "{{ wait.trigger.id == 'persistent_cleared' }}"
+                          sequence:
+                            alias: Disable persistent notifications
+                            variables:
+                              persistent_active: false
+                        - alias: If triggered by a notify condition change
+                          conditions:
+                            - condition: template
+                              value_template: "{{ wait.trigger.id == 'conditions_changed' }}"
+                          sequence:
+                            - variables:
+                                active_notify_services: *get_active_services
+                        - alias: If travel time remaining needs to trigger nearly arrived TTS
+                          conditions:
+                            - condition: template
+                              value_template: |-
+                                {{ nearly_arrived_tts
+                                  and not nearly_arrived_sent
+                                  and nearly_arrived_timestamp is not none
+                                  and nearly_arrived_timestamp <= now() | as_timestamp
+                                  and speaker_tts_service != ''
+                                }}
+                          sequence:
+                            - alias: Get TTS translation
+                              variables:
+                                message_id: "nearly_arrived"
+                                message: *get_message
+                            - alias: Format the notification message
+                              variables:
+                                message: |-
+                                  {{
+                                    message.format(
+                                      driver_name=driver_name,
+                                      remaining_minutes=(
+                                        (
+                                          arrival_timestamp
+                                          - now() | as_timestamp
+                                        ) / 60
+                                      ) | round
+                                    )
+                                  }}
+                            - sequence: *play_speaker_tts
+                            - alias: Mark nearly arrived TTS as already sent
+                              variables:
+                                nearly_arrived_sent: true
+                        - alias: If triggered by travel time update and notifications are not on cooldown
+                          conditions:
+                            - condition: template
+                              value_template: |-
+                                {{
+                                  wait.trigger.id == 'travel_time'
+                                  and next_refresh <= now() | as_timestamp
+                                }}
+                          sequence:
+                            - alias: Calculate ETA
+                              variables:
+                                remaining: |-
+                                    {% if state_attr(travel_time_sensor, 'duration') != none %}
+                                      {{ state_attr(travel_time_sensor, 'duration') | float * 60 }}
+                                    {% elif state_attr(travel_time_sensor, 'unit_of_measurement') == "min" %}
+                                      {{ states(travel_time_sensor) | float * 60 }}
+                                    {% elif state_attr(travel_time_sensor, 'unit_of_measurement') == "s" %}
+                                      {{ states(travel_time_sensor) | float }}
+                                    {% else %}
+                                      {{ none }}
+                                    {% endif %}
+                            - alias: Stop if travel time integration is not supported
+                              if:
+                                - condition: template
+                                  value_template: "{{ remaining is none }}"
+                              then:
+                                - alias: Get notification translation
+                                  variables:
+                                    message_id: "unsupported_tt_integration"
+                                    message: *get_message
+                                - alias: Notify all users on the dashboard that the integration is unsupported
+                                  action: persistent_notification.create
+                                  data:
+                                    title: "{{ title }}"
+                                    message: "{{ message }}"
+                                    notification_id: "{{ persistent_id }}"
+                                - stop: Travel time integration not supported
+                                  error: true
+                            - alias: Calculate next refresh
+                              variables:
+                                cooldown: !input notif_refresh_rate_ftn
+                                next_refresh: "{{ now() | as_timestamp + cooldown }}"
+                            - alias: Convert ETA to needed types
+                              variables:
+                                arrival_timestamp: "{{ as_timestamp(now()) + remaining }}"
+                                arrival: "{{ arrival_timestamp | timestamp_custom('%H:%M') }}"
+                            - alias: If the nearly arrived tts has not been triggered yet
+                              if:
+                                - condition: template
+                                  value_template: |-
+                                    {{
+                                      nearly_arrived_tts
+                                      and not nearly_arrived_sent
+                                    }}
+                              then:
+                                - alias: Calculate the timestamp for the nearly arrived tts trigger
+                                  variables:
+                                    nearly_arrived_timestamp: "{{ arrival_timestamp - nearly_arrived_time*60 }}"
+                            - alias: Do not send notification if the time of arrival did not change
+                              condition: template
+                              value_template: |-
+                                {# If the next notification will be sent near the arrival #}
+                                {% if arrival_timestamp - next_refresh < 120 %}
+                                  {# Refresh notification if eta differs by at least 5s #}
+                                  {{
+                                    (
+                                      last_arrival_timestamp | int
+                                      - arrival_timestamp | int
+                                    ) | abs > 5
+                                  }}
+                                {% else %}
+                                  {# Refresh notification if eta differs by at least 1min #}
+                                  {{
+                                    (last_arrival_timestamp / 60) | int
+                                    != (arrival_timestamp / 60) | int
+                                  }}
+                                {% endif %}
+                            - alias: Save the current time of arrival
+                              variables:
+                                last_arrival_timestamp: "{{ arrival_timestamp }}"
+                            - alias: Get notification translation
+                              variables:
+                                message_id: "itinerary_ongoing"
+                                message: *get_message
+                            - alias: Format the notification message
+                              variables:
+                                message: |-
+                                  {{
+                                    message.format(
+                                      arrival=arrival,
+                                      driver_name=driver_name
+                                    )
+                                  }}
+                            - alias: Send ETA notification to each user
+                              repeat:
+                                for_each: "{{ active_notify_services }}"
+                                sequence:
+                                  - action: "{{ repeat.item }}"
+                                    data:
+                                      message: "{{ message }}"
+                                      data:
+                                        <<: *notification_data
+                                        notification_icon: mdi:map-marker-account
+                                        chronometer: true
+                                        when: "{{ arrival_timestamp | int }}"
+                            - alias: If persistent notifications are still active
+                              if:
+                                - condition: template
+                                  value_template: "{{ persistent_active }}"
+                              then:
+                                - alias: Update the persistent notification
+                                  action: persistent_notification.create
+                                  data:
+                                    message: "{{ message }}"
+                                    notification_id: "{{ persistent_id }}"
+                        - alias: If the timer needs to be removed from the notification
+                          conditions: |-
+                            {{
+                              arrival_timestamp is not none
+                              and arrival_timestamp <= now() | as_timestamp
+                              and not timer_removed
+                            }}
+                          sequence:
+                            - alias: Get notification translation
+                              variables:
+                                message_id: "soon_arrived"
+                                message: *get_message
+                            - alias: Format the notification message
+                              variables:
+                                message: "{{ message.format(driver_name=driver_name) }}"
+                            - alias: Send soon arrived notification to each user
+                              repeat:
+                                for_each: "{{ active_notify_services }}"
+                                sequence:
+                                  - action: "{{ repeat.item }}"
+                                    data:
+                                      message: "{{ message }}"
+                                      data:
+                                        <<: *notification_data
+                                        notification_icon: mdi:map-marker-account
+                            - alias: Remember that the timer was removed
+                              variables:
+                                timer_removed: true
+            else:
+              - alias: Wait for user to leave vehicle
+                wait_for_trigger:
+                  - trigger: template
+                    id: vehicle_left
+                    value_template: "{{ is_state(driving_sensor, 'off') }}"
+          - alias: If driver arrived home
+            if:
+              condition: template
+              value_template: "{{ is_state(driver, 'home') }}"
+            then:
+              - alias: Get notification translation
+                variables:
+                  message_id: "driver_arrived"
+                  message: *get_message
+              - alias: Format the notification message
+                variables:
+                  message: "{{ message.format(driver_name=driver_name) }}"
+              - parallel:
+                  - alias: Send arrival notification to each user
+                    repeat:
+                      for_each: "{{ active_notify_services }}"
+                      sequence:
+                        - action: "{{ repeat.item }}"
                           data:
                             message: "{{ message }}"
-                            notification_id: "{{ persistent_id }}"
-                - alias: If the timer needs to be removed from the notification
-                  conditions: |-
-                    {{
-                      arrival_timestamp is not none
-                      and arrival_timestamp <= now() | as_timestamp
-                      and not timer_removed
-                    }}
-                  sequence:
-                    - alias: Get notification translation
-                      variables:
-                        message_id: "soon_arrived"
-                        message: *get_message
-                    - alias: Format the notification message
-                      variables:
-                        message: "{{ message.format(driver_name=driver_name) }}"
-                    - alias: Send soon arrived notification to each user
-                      repeat:
-                        for_each: "{{ active_notify_services }}"
-                        sequence:
-                          - action: "{{ repeat.item }}"
                             data:
-                              message: "{{ message }}"
-                              data:
-                                <<: *notification_data
-                                notification_icon: mdi:map-marker-account
-                    - alias: Remember that the timer was removed
-                      variables:
-                        timer_removed: true
-    else:
-      - alias: Wait for user to leave vehicle
-        wait_for_trigger:
-          - trigger: template
-            id: vehicle_left
-            value_template: "{{ is_state(driving_sensor, 'off') }}"
-  - alias: If driver arrived home
-    if:
-      condition: template
-      value_template: "{{ is_state(driver, 'home') }}"
-    then:
-      - alias: Get notification translation
-        variables:
-          message_id: "driver_arrived"
-          message: *get_message
-      - alias: Format the notification message
-        variables:
-          message: "{{ message.format(driver_name=driver_name) }}"
-      - alias: Send arrival notification to each user
-        repeat:
-          for_each: "{{ active_notify_services }}"
-          sequence:
-            - action: "{{ repeat.item }}"
-              data:
-                message: "{{ message }}"
-                data:
-                  notification_icon: mdi:home-map-marker
-                  tag: "{{ notification_tag }}"
-                  channel: Itinerary status
-                  url: !input on_tap_link
-                  clickAction: !input on_tap_link
-                  timeout: 300
-      - alias: If persistent notifications are still active
-        if:
-          - condition: template
-            value_template: "{{ persistent_active }}"
-        then:
-          - alias: Update the persistent notification
-            action: persistent_notification.create
-            data:
-              message: "{{ message }}"
-              notification_id: "{{ persistent_id }}"
+                              notification_icon: mdi:home-map-marker
+                              tag: "{{ notification_tag }}"
+                              channel: Itinerary status
+                              url: !input on_tap_link
+                              clickAction: !input on_tap_link
+                              timeout: 300
+                  - alias: If persistent notifications are still active
+                    if:
+                      - condition: template
+                        value_template: "{{ persistent_active }}"
+                    then:
+                      - alias: Update the persistent notification
+                        action: persistent_notification.create
+                        data:
+                          message: "{{ message }}"
+                          notification_id: "{{ persistent_id }}"
 
-      - alias: If driver_arrived_tts is enabled
-        if:
-          - condition: template
-            value_template: !input driver_arrived_tts
-        then: *play_speaker_tts
-    else:
-      - alias: Remove itinerary notification for each user
-        repeat:
-          for_each: "{{ active_notify_services }}"
-          sequence:
-            - action: "{{ repeat.item }}"
-              data:
-                message: clear_notification
-                data:
-                  tag: "{{ notification_tag }}"
+                  - alias: If driver_arrived_tts is enabled
+                    if:
+                      - condition: template
+                        value_template: !input driver_arrived_tts
+                    then: *play_speaker_tts
+            else:
+              - alias: Remove itinerary notification for each user
+                repeat:
+                  for_each: "{{ active_notify_services }}"
+                  sequence:
+                    - action: "{{ repeat.item }}"
+                      data:
+                        message: clear_notification
+                        data:
+                          tag: "{{ notification_tag }}"
 mode: parallel


### PR DESCRIPTION
If a device is slow to respond (e.g.: a speaker sleeping), others actions will be executed sooner than before (e.g.: extra actions in gate alerts)