### PR TITLE
Fix closing sequence not triggering with some gates

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -2758,8 +2758,21 @@ actions:
                   id: "{{ none }}"
           - alias: If one of the gates is open
             if:
-              - condition: template
-                value_template: *gate_open
+              - condition: or
+                conditions:
+                  - alias: Gate open
+                    condition: template
+                    value_template: *gate_open
+                  - alias: Opening request sent but not acknowledged yet
+                    condition: template
+                    value_template: |-
+                      {{
+                        gate
+                        | select('is_state', ['unknown', 'unavailable'])
+                        | list
+                        != gate
+                        and opening_behavior != 'off'
+                      }}
             then:
               - alias: If BLE devices are needed to close the gate
                 if:


### PR DESCRIPTION
If the gate opening action does not wait for an acknowledgment from the gate, the closing sequence will start before the gate has reported its opening. Since the gate won't report being opened, the closing sequence will be skipped. This commit fixes this bug by checking if the opening sequence was started.