### PR TITLE
Wait for *all* gates to be manually opened/closed

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -2223,7 +2223,13 @@ actions:
                 - alias: Gates closed
                   trigger: template
                   id: gate_closed
-                  value_template: "{{ gate | select('is_state', ['off', 'closed', 'closing']) | list == gate }}"
+                  value_template: &all_gates_closed |-
+                    {{
+                      gate
+                      | select('is_state', ['off', 'closed', 'closing'])
+                      | list
+                      == gate
+                    }}
                   enabled: "{{ gates_were_opened }}"
               timeout: |-
                 {{
@@ -2588,7 +2594,7 @@ actions:
           - alias: If one of the gates is closed
             if:
               - condition: template
-                value_template: &gate_closed |-
+                value_template: |-
                   {{
                     gate
                     | select('is_state', ['off', 'closed', 'closing'])
@@ -2712,7 +2718,7 @@ actions:
                             - alias: Manual opening
                               trigger: template
                               id: manual
-                              value_template: *gate_open
+                              value_template: *all_gates_open
                             - alias: Vehicle left
                               trigger: template
                               id: vehicle_stopped
@@ -2916,7 +2922,7 @@ actions:
                         - alias: Manual closing
                           trigger: template
                           id: manual
-                          value_template: *gate_closed
+                          value_template: *all_gates_closed
                         - alias: BLE out of reach
                           trigger: template
                           id: ble_out_of_range
@@ -3229,10 +3235,10 @@ actions:
                                 <<: *notification_data
                                 notification_icon: mdi:sleep
                           - sequence: *tts
-                      - alias: Wait for gate closed
+                      - alias: Wait for manual gate closing
                         wait_for_trigger:
                           - trigger: template
-                            value_template: *gate_closed
+                            value_template: *all_gates_closed
                       - alias: If a notify service exists
                         if:
                           - condition: template


### PR DESCRIPTION
If multiple gates are set, wait for all gates to be triggered to skip some sequences (instead of only one).

e.g.: If an opening notification was sent to the user, and he manually opened one of his gates, the blueprint will wait for the others to be opened too before starting to listen for closing triggers. Previously, it would have started to wait for closing triggers once one of the gates was opened.