### PR TITLE
Fix gate alerts error after configuration

### DIFF
--- a/Blueprints/Gate-Alerts/gate-alerts.yaml
+++ b/Blueprints/Gate-Alerts/gate-alerts.yaml
@@ -326,6 +326,7 @@ variables:
 
 trigger_variables:
   notification_type: !input notification_type
+  error_message_sensor: !input error_message_sensor
   gate: !input gate
 
 triggers:
@@ -360,13 +361,9 @@ triggers:
     enabled: "{{ notification_type == 'close' }}"
 
   - alias: Wait for error
-    trigger: state
+    trigger: template
     id: error
-    entity_id: !input error_message_sensor
-    not_to:
-      - "unknown"
-      - "unavailable"
-      - ""
+    value_template: "{{ error_message_sensor | has_value }}"
     enabled: "{{ notification_type == 'error' }}"
 
   - alias: Wait for gate unavailable for duration


### PR DESCRIPTION
I had changed the default value of this sensor input from [] to "", but state triggers raise an error when receiving a "" value. I have changed the trigger type to template to fix this.

<!--
  Thanks for your contribution ! Please fill in the inputs below.
-->

## PR category 🏷️
<!--
  What will be impacted by your PR ?
-->

- [x] Blueprint
- [ ] Dashboard
- [ ] ESPHome
- [ ] Extra
- [ ] Other

## Type of change ✏️
<!--
  What type of change does your PR introduce to this repository ?
-->

- [ ] New feature
- [ ] New test
- [ ] New translations
- [x] Bugfix
- [ ] Translations fix
- [ ] Code quality improvements
- [ ] Documentation update
- [ ] New project

## Proposed change 🛠️
<!--
  What will this PR change in this repository ?
-->
Fix Gate Alerts configuration error