### PR TITLE
Add on notification tap link to Gate Alerts

### DIFF
--- a/Blueprints/Gate-Alerts/gate-alerts.yaml
+++ b/Blueprints/Gate-Alerts/gate-alerts.yaml
@@ -128,6 +128,14 @@ blueprint:
           default: true
           selector:
             boolean:
+        on_tap_link:
+          name: 👆 On tap link
+          description: |-
+            The **link** you will go to if you **tap** on the notification
+            > *Can be Home Assistant relative links*
+          default: "/lovelace/garage-camera"
+          selector:
+            text:
         persistent_notification:
           name: 🔔 Persistent notifications
           description: Show notifications in Home Assistant **[dashboard](https://www.home-assistant.io/integrations/persistent_notification)**
@@ -699,6 +707,8 @@ actions:
                   sticky: true
                   persistent: true
                   tag: "{{ notification_tag }}"
+                  url: !input on_tap_link
+                  clickAction: !input on_tap_link
                   alert_once: true
                   actions:
                     - action: "{{ closing_order_id }}"
@@ -772,6 +782,8 @@ actions:
                           name: "default"
                           critical: "{{ int(car_visible) }}"
                       tag: "{{ notification_tag }}"
+                      url: !input on_tap_link
+                      clickAction: !input on_tap_link
                       timeout: >-
                         {% if notification_type == 'error' or is_state(gate, ['off', 'closed']) %}
                           30


### PR DESCRIPTION
<!--
  Thanks for your contribution ! Please fill in the inputs below.
-->

## PR category 🏷️
<!--
  What will be impacted by your PR ?
-->

- [ ] Blueprint
- [ ] Dashboard
- [ ] ESPHome
- [ ] Extra
- [ ] Other

## Type of change ✏️
<!--
  What type of change does your PR introduce to this repository ?
-->

- [ ] New feature
- [ ] New test
- [ ] New translations
- [ ] Bugfix
- [ ] Translations fix
- [ ] Code quality improvements
- [ ] Documentation update
- [ ] New project

## Proposed change 🛠️
<!--
  What will this PR change in this repository ?
-->
Add an input to let the notification open an url when tapped (e.g.: a Home Assistant dasboard with a camera feed showing your gate)
