### PR TITLE
Fix manual closing not stopping the closing sequence

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -3821,29 +3821,47 @@ actions:
                             enabled: "{{ wait_notif_reception }}"
                         timeout:
                           seconds: "{{ trigger_timeout }}"
-                      - alias: If a safety feature needs to change the closing behavior from notif to timer
-                        if:
-                          - condition: template
-                            value_template: >-
-                              {{
-                                security_notif_override
-                                and closing_behavior == 'notif'
-                                and (
-                                  not wait.completed
-                                    and timeout_type == 'safety_delay'
-                                  or wait.completed and wait.trigger.id in [
-                                    'vehicle_stopped',
-                                    'vehicle_away',
-                                    'forbidden_zone',
-                                  ]
-                                )
-                              }}
-                        then:
-                          - alias: Change closing behavior to timer
-                            variables:
-                              closing_behavior: "timer"
-                              timer_reset_timestamp: "{{ now() | as_timestamp }}"
-                              wait_notif_reception: "{{ not ios_device }}"
+                      - choose:
+                          - alias: If a safety feature needs to change the closing behavior from notif to timer
+                            conditions:
+                              - condition: template
+                                value_template: >-
+                                  {{
+                                    security_notif_override
+                                    and closing_behavior == 'notif'
+                                    and (
+                                      not wait.completed
+                                        and timeout_type == 'safety_delay'
+                                      or wait.completed and wait.trigger.id in [
+                                        'vehicle_stopped',
+                                        'vehicle_away',
+                                        'forbidden_zone',
+                                      ]
+                                    )
+                                  }}
+                            sequence:
+                              - alias: Change closing behavior to timer
+                                variables:
+                                  closing_behavior: "timer"
+                                  timer_reset_timestamp: "{{ now() | as_timestamp }}"
+                                  wait_notif_reception: "{{ not ios_device }}"
+                          - alias: If the trigger needs to close the gate
+                            conditions:
+                              - condition: template
+                                value_template: >-
+                                  {{
+                                    wait.completed and wait.trigger.id in [
+                                      'manual', 'closing_order'
+                                    ]
+                                    or (
+                                      not wait.completed
+                                      and timeout_type == 'timer'
+                                    )
+                                  }}
+                            sequence:
+                              - alias: Break the loop
+                                variables:
+                                  break: true
                       - choose:
                           - alias: If this is the first loop or the behavior just switched to timer
                             conditions:
@@ -3951,23 +3969,6 @@ actions:
                                       message: "{{ message }}"
                                       data: "{{ notification_data }}"
                                   - sequence: *tts
-                          - alias: If the trigger needs to close the gate
-                            conditions:
-                              - condition: template
-                                value_template: >-
-                                  {{
-                                    wait.completed and wait.trigger.id in [
-                                      'manual', 'closing_order'
-                                    ]
-                                    or (
-                                      not wait.completed
-                                      and timeout_type == 'timer'
-                                    )
-                                  }}
-                            sequence:
-                              - alias: Break the loop
-                                variables:
-                                  break: true
                           - alias: If the itinerary needs to be canceled
                             conditions:
                               - condition: template


### PR DESCRIPTION
<!--
  Thanks for your contribution ! Please fill in the inputs below.
-->

## PR category 🏷️
<!--
  What will be impacted by your PR ?
-->

- [x] Blueprint
- [ ] Dashboard
- [ ] ESPHome
- [ ] Extra
- [ ] Other

## Type of change ✏️
<!--
  What type of change does your PR introduce to this repository ?
-->

- [ ] New feature
- [ ] New test
- [ ] New translations
- [x] Bugfix
- [ ] Translations fix
- [ ] Code quality improvements
- [ ] Documentation update
- [ ] New project

## Proposed change 🛠️
<!--
  What will this PR change in this repository ?
-->
After manually closing the gate and going far away from home, a notification would be sent to ask to close the gate, even though it was already closed.
With this change, the Automatic Gate now stops waiting for events when the gate is manually closed.