### PR TITLE
Add a maximum distance to trigger the automation

### DIFF
--- a/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
+++ b/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
@@ -89,7 +89,7 @@ blueprint:
       collapsed: true
       input:
         dead_zone:
-          name: 📍 Dead zone
+          name: 📍 Minimum distance
           description: |-
             **Minimum distance** between the driver and home to trigger the automation
           default: 500
@@ -97,6 +97,15 @@ blueprint:
             number:
               min: 300
               max: 5000
+              unit_of_measurement: m
+        dead_zone_max:
+          name: 📍 Maximum distance
+          description: |-
+            **Maximum distance** between the driver and home to trigger the automation
+            > This will be disabled if set to 0
+          default: 0
+          selector:
+            number:
               unit_of_measurement: m
 
     persons_to_notify:
@@ -281,6 +290,7 @@ blueprint:
 variables:
   MAX_INT: 2147483647
   dead_zone: !input dead_zone
+  dead_zone_max: !input dead_zone_max
   persons: !input persons
   notify_devices: !input notify_devices
   notify_services: >-
@@ -728,20 +738,53 @@ actions:
         and (not error_checker_ran or error_level < 2)
       }}
 
+  - alias: Get the distance from home of the driver
+    variables:
+      home_distance: >-
+        {% if state_attr(driver, 'gps_accuracy') is none %}
+          {% set accuracy = 100 %}
+        {% else %}
+          {% set accuracy = state_attr(driver, 'gps_accuracy') %}
+        {% endif %}
+        {{ distance(driver, 'zone.home')*1000 - accuracy }}
   - alias: Only continue if driver not in the dead zone
     condition: template
     value_template: >-
-      {% if state_attr(driver, 'gps_accuracy') is none %}
-        {% set accuracy = 100 %}
-      {% else %}
-        {% set accuracy = state_attr(driver, 'gps_accuracy') %}
-      {% endif %}
-      {% set home_distance = distance(driver, 'zone.home')*1000 - accuracy %}
       {{ home_distance >= dead_zone }}
   - alias: Get notification translation
     variables:
       message_id: "itinerary_started"
       message: *get_message
+  - alias: If the driver is too far away from home
+    if:
+      - condition: template
+        value_template: >-
+          {{
+            dead_zone_max != 0
+            and dead_zone_max < home_distance
+          }}
+    then:
+      - alias: Wait for the user to come back into the zone
+        wait_for_trigger:
+          - alias: Returned in zone
+            trigger: template
+            id: returned_in_zone
+            value_template: >-
+              {% if state_attr(driver, 'gps_accuracy') is none %}
+                {% set accuracy = 100 %}
+              {% else %}
+                {% set accuracy = state_attr(driver, 'gps_accuracy') %}
+              {% endif %}
+              {% set home_distance = distance(driver, 'zone.home')*1000 - accuracy %}
+              {{ dead_zone <= home_distance <= dead_zone_max }}
+          - alias: Vehicle stopped
+            trigger: template
+            id: vehicle_stopped
+            value_template: "{{ is_state(driving_sensor, 'off') }}"
+      - alias: Only continue this sequence if the driver stopped his vehicle
+        condition: template
+        value_template: "{{ wait.trigger.id == 'vehicle_stopped' }}"
+      - stop: Vehicle left
   - alias: Format the notification message
     variables:
       message: "{{ message.format(driver_name=driver_name) }}"

--- a/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
+++ b/Blueprints/Itinerary-Tracker-Notification/itinerary-tracker-notification.yaml
@@ -345,6 +345,7 @@ variables:
         no_notification_method: "You have not entered any method for receiving notifications (#17)"
         night_mode_missing_bound: "A bound for the speakers' night mode schedule is missing (#18)"
         deprecated_translations: "Custom translations now use a yaml dictionnary instead of json. Please update your old config. (#21)"
+        invalid_dead_zone: "Your dead zone is invalid (#27)"
     fr:
       title:
         valid_config: "{{blueprint_name}}: Configuration valide 🛠️✅"
@@ -366,6 +367,7 @@ variables:
         no_notification_method: "Vous n'avez entré aucune méthode pour recevoir les notifications (#17)"
         night_mode_missing_bound: "Il manque une borne des horaires du mode nuit des enceintes (#18)"
         deprecated_translations: "Les traductions personnalisés utilisent maintenant un dictionnaire yaml au lieu de json. Mettez à jour votre configuration svp. (#21)"
+        invalid_dead_zone: "Votre zone morte est invalide (#27)"
 
 triggers:
   - alias: Trigger when user connects to vehicle
@@ -586,6 +588,10 @@ actions:
                   error: "{{ custom_translations_error }}"
                   message_id: "deprecated_translations"
                   level: 0
+                - alias: Check dead zone values
+                  error: "{{ dead_zone_max != 0 and dead_zone_max <= dead_zone }}"
+                  message_id: "invalid_dead_zone"
+                  level: 2
               sequence:
                 - alias: If a check failed
                   if:

--- a/Blueprints/README.md
+++ b/Blueprints/README.md
@@ -66,5 +66,6 @@ Refer to the table below to fix the errors
   | #24 | You have enabled GPS requests, but your travel time refresh is neither set to 'Continuously' nor 'Listen' | Either untick 'Request gps location', or add a travel time sensor and set the refresh rate to 'Continuously' or 'Listen' |
   | #25 | You have set some gate behaviors to 'Notification request' or 'Cancelable timer', but some users are missing a notify device. These behaviors will be switched to 'Fully Automatic' | Either set these behaviors to 'Off' or 'Fully Automatic', or add missing notification devices |
   | #26 | These iBeacon transmitter entities: '...' do not come the associated notification device | Either make sure that these transmitter entities come from your notification device, or remove them (but you will have to always keep your iBeacon on) |
+  | #27 | Your dead zone is invalid | Either set the 'Maximum distance' input to 0, or set a value higher than the 'Minimum distance' |
   
 </details>


### PR DESCRIPTION
<!--
  Thanks for your contribution ! Please fill in the inputs below.
-->

## PR category 🏷️
<!--
  What will be impacted by your PR ?
-->

- [x] Blueprint
- [ ] Dashboard
- [ ] ESPHome
- [ ] Extra
- [ ] Other

## Type of change ✏️
<!--
  What type of change does your PR introduce to this repository ?
-->

- [x] New feature
- [ ] New test
- [ ] New translations
- [ ] Bugfix
- [ ] Translations fix
- [ ] Code quality improvements
- [ ] Documentation update
- [ ] New project

## Proposed change 🛠️
<!--
  What will this PR change in this repository ?
-->
Added a maximum zone to trigger the Itinerary Tracker blueprint.
If you are too far away (e.g.: on vacation), you won't receive notifications when driving.
If you come back into the zone, the blueprint will trigger.