### PR TITLE
Fix too close error not being raised

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -2760,6 +2760,26 @@ actions:
                     )
                   }}
             - choose:
+                - alias: Stop if driver started driving in activation zone
+                  conditions:
+                    - condition: template
+                      value_template: *activation_zone_in_condition
+                    - condition: template
+                      value_template: "{{ repeat.first }}"
+                  sequence:
+                    - alias: Set error id
+                      variables:
+                        message_id: "too_close"
+                    - alias: Send a silent error if the behaviors are set to off
+                      variables:
+                        silent_error: >-
+                          {{
+                            behavior.departure.opening == 'off'
+                            and behavior.departure.closing == 'off'
+                          }}
+                    - alias: Create error
+                      sequence: *create_error
+                    - stop: Started too close to home
                 - alias: If driver at gate location
                   conditions:
                     - condition: template
@@ -2848,26 +2868,6 @@ actions:
                                   recursive=True
                                 )
                               }}
-                - alias: Stop if driver started driving in activation zone
-                  conditions:
-                    - condition: template
-                      value_template: *activation_zone_in_condition
-                    - condition: template
-                      value_template: "{{ repeat.first }}"
-                  sequence:
-                    - alias: Set error id
-                      variables:
-                        message_id: "too_close"
-                    - alias: Send a silent error if the behaviors are set to off
-                      variables:
-                        silent_error: >-
-                          {{
-                            behavior.departure.opening == 'off'
-                            and behavior.departure.closing == 'off'
-                          }}
-                    - alias: Create error
-                      sequence: *create_error
-                    - stop: Started too close to home
               default:
                 ###########
                 # ARRIVAL #


### PR DESCRIPTION
<!--
  Thanks for your contribution ! Please fill in the inputs below.
-->

## PR category 🏷️
<!--
  What will be impacted by your PR ?
-->

- [x] Blueprint
- [ ] Dashboard
- [ ] ESPHome
- [ ] Extra
- [ ] Other

## Type of change ✏️
<!--
  What type of change does your PR introduce to this repository ?
-->

- [ ] New feature
- [ ] New test
- [ ] New translations
- [x] Bugfix
- [ ] Translations fix
- [ ] Code quality improvements
- [ ] Documentation update
- [ ] New project

## Proposed change 🛠️
<!--
  What will this PR change in this repository ?
-->
If the driver started driving away from home, but in the activation zone, the blueprint was not stopping, and the gate was opened.