### PR TITLE
Avoid reopening when user comes back on feet after stopping his vehicle on departure

### DIFF
--- a/Blueprints/Automatic-Gate/automatic-gate.yaml
+++ b/Blueprints/Automatic-Gate/automatic-gate.yaml
@@ -4272,6 +4272,12 @@ actions:
                 - condition: template
                   value_template: "{{ departure_mode }}"
               then:
+                - alias: Avoid looping if the driver has stopped his vehicle on departure
+                  if:
+                    - condition: template
+                      value_template: "{{ is_state(driving_sensor, 'off') }}"
+                  then:
+                    - stop: Vehicle stopped
                 - alias: Wait for driver to travel 250m away from activation zone, then return, to start itinerary
                   repeat:
                     count: 2


### PR DESCRIPTION
<!--
  Thanks for your contribution ! Please fill in the inputs below.
-->

## PR category 🏷️
<!--
  What will be impacted by your PR ?
-->

- [x] Blueprint
- [ ] Dashboard
- [ ] ESPHome
- [ ] Extra
- [ ] Other

## Type of change ✏️
<!--
  What type of change does your PR introduce to this repository ?
-->

- [ ] New feature
- [ ] New test
- [ ] New translations
- [x] Bugfix
- [ ] Translations fix
- [ ] Code quality improvements
- [ ] Documentation update
- [ ] New project

## Proposed change 🛠️
<!--
  What will this PR change in this repository ?
-->
If a user started his vehicle at home, then stopped it before leaving the activation zone, the Automatic Gate blueprint would continue running.
Then, when the user would go far away from home then come back, the blueprint would open the gate thinking the user was still driving.
This is not truly a severe issue, since the gate would only open when the user would be near home.